### PR TITLE
feat: restricts based on authentication

### DIFF
--- a/client/src/context/auth.tsx
+++ b/client/src/context/auth.tsx
@@ -1,5 +1,6 @@
-import { createContext, useContext, useReducer } from "react";
+import { createContext, useContext, useEffect, useReducer } from "react";
 import { User } from "../types";
+import axios from "axios";
 
 interface State {
     authenticated: boolean;
@@ -51,12 +52,24 @@ export const AuthProvider = ({ children }:{ children: React.ReactNode }) => {
         loading: true,
     })
 
-    console.log('state', state);
-
     const dispatch = (type: string, payload?: any) => {
         defaultDispatch({ type, payload });
     }
 
+    useEffect(() => {
+        async function loadUser() {
+            try {
+                const res = await axios.get("/auth/me");
+                dispatch("LOGIN", res.data); // 백엔드에서 오는 유저 정보를 LOGIN에 넣어줌
+            } catch (error) {
+                console.log(error);
+            } finally {
+                dispatch("STOP_LOADING");
+            }
+        }
+        loadUser(); // 컴포넌트가 마운트 되자마자 함수 호출
+    }, [])
+    
     return (
         <DispatchContext.Provider value={dispatch}>
             <StateContext.Provider value={state}>{children}</StateContext.Provider>

--- a/client/src/pages/login.tsx
+++ b/client/src/pages/login.tsx
@@ -3,7 +3,7 @@ import axios from 'axios';
 import Link from 'next/link'
 import { useRouter } from 'next/router';
 import InputGroup from '../components/InputGroup'
-import { useAuthDispatch } from '../context/auth';
+import { useAuthDispatch, useAuthState } from '../context/auth';
 
 const Login = () => {
     let router = useRouter();
@@ -11,6 +11,9 @@ const Login = () => {
     const [password, setPassword] = useState("");
     const [errors, setErrors] = useState<any>({});  
     const dispatch = useAuthDispatch();
+    const {authenticated} = useAuthState();
+    
+    if(authenticated) router.push("/");
 
     const handleSubmit = async (event: FormEvent) => {
         event.preventDefault();

--- a/client/src/pages/register.tsx
+++ b/client/src/pages/register.tsx
@@ -3,14 +3,17 @@ import Link from 'next/link'
 import { useRouter } from 'next/router';
 import React, { FormEvent, useState } from 'react'
 import InputGroup from '../components/InputGroup'
+import { useAuthState } from '../context/auth';
 
 const Register = () => {
     const [email, setEmail] = useState("");
     const [username, setUsername] = useState("");
     const [password, setPassword] = useState("");
     const [errors, setErrors] = useState<any>({});    
+    const {authenticated} = useAuthState();
 
     let router = useRouter();
+    if(authenticated) router.push("/");
 
     const handleSubmit = async (event: FormEvent) => {
         event.preventDefault();

--- a/client/src/pages/subs/create.tsx
+++ b/client/src/pages/subs/create.tsx
@@ -1,5 +1,6 @@
 import InputGroup from "@/src/components/InputGroup";
 import axios from "axios";
+import { GetServerSideProps } from "next";
 import { useRouter } from "next/router";
 import { FormEvent, useState } from "react";
 
@@ -79,3 +80,20 @@ const SubCreate = () => {
 };
 
 export default SubCreate;
+
+export const getServerSideProps: GetServerSideProps = async ({req, res}) => {
+    try {
+        const cookie = req.headers.cookie;
+        // 요청을 보낼 때 쿠키가 없다면 에러 보내기
+        if (!cookie) throw new Error("Missing auth token cookie");
+
+        // 쿠키가 있다면 그 쿠키를 이용해서 백엔드에서 인증 처리
+        await axios.get("/auth/me", { headers: { cookie } });
+
+        return { props: {} };
+    } catch (error) {
+        // 백엔드에서 요청에서 던져준 쿠키를 이용해 인증 처리할 떄 에러가 나면 /login 페이지로 이동
+        res.writeHead(307, { Location: "/login" }).end();
+        return { props: {} };
+    }
+}

--- a/server/src/middlewares/user.ts
+++ b/server/src/middlewares/user.ts
@@ -17,6 +17,8 @@ export default async (req: Request, res: Response, next: NextFunction) => {
 
         // 유저 정보를 res.local.user에 넣어주기
         res.locals.user = user;
+        
+        return next();
     } catch (error) {
         console.log(error);
         return res.status(400).json({ error: "Something went wrong" });        

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -4,12 +4,18 @@ import bcrypt from "bcryptjs";
 import jwt from "jsonwebtoken";
 import cookie from "cookie";
 import User from "../entities/User";
+import userMiddleware from "../middlewares/user";
+import authMiddleware from "../middlewares/auth";
 
 const mapError = (errors: Object[]) => {
     return errors.reduce((prev: any, err: any) => {
         prev[err.property] = Object.entries(err.constraints)[0][1];
         return prev;
     }, {});
+}
+
+const me = async (_: Request, res: Response) => {
+    return res.json(res.locals.user);
 }
 
 const register = async (req: Request, res: Response) => {
@@ -96,6 +102,7 @@ const login = async (req: Request, res: Response) => {
 }
 
 const router = Router();
+router.get("/me", userMiddleware, authMiddleware, me);
 router.post("/register", register);
 router.post("/login", login);
 


### PR DESCRIPTION
## Overview
- 로그인 안 된 상태로 커뮤니티 생성 페이지 접근하면 Redirect /login
- 로그인 후 로그인 및 회원가입 페이지 접근하면 Redirect /main

## Change Log
**[Before login]**
- `client/src/pages/subs/create.tsx` getServerSideProps
  - 쿠키 확인하여 로그인 유무 확인
    - 쿠키가 있으면 /auth/me에서 인증 처리
    - 쿠키가 없으면 **Redirect /login**
- `server/src/routes/auth.ts` me API 구현, user, auth middlewares 와 함께 호출

**[After login]**
- `client/src/context/auth.tsx` loadUser()
  - 컴포넌트가 마운트 되면 loadUser 함수가 호출되고,
    - 백엔드에서 오는 유저 정보가 있으면 authenticated: true가 되어
    - login, register 페이지에 들어가면 바로 **Redirect /**
    - 로그인 정보 있든 없든 loading: false로 변경

## Issue Tags
- Closed: #17 