### PR TITLE
feat: show top communities list in main page

### DIFF
--- a/client/next.config.mjs
+++ b/client/next.config.mjs
@@ -1,6 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  images:{
+    domains: ["www.gravatar.com"]
+  }
 };
 
 export default nextConfig;

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -11,7 +11,8 @@
         "classnames": "^2.5.1",
         "next": "14.2.3",
         "react": "^18",
-        "react-dom": "^18"
+        "react-dom": "^18",
+        "swr": "^2.2.5"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -6175,6 +6176,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swr": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.2.5.tgz",
+      "integrity": "sha512-QtxqyclFeAsxEUeZIYmsaQ0UjimSq1RZ9Un7I68/0ClKK/U3LoyQunwkQfJZr2fc22DfIXLNDc2wFyTEikCUpg==",
+      "dependencies": {
+        "client-only": "^0.0.1",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "3.4.4",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.4.tgz",
@@ -6463,6 +6476,14 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz",
+      "integrity": "sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/client/package.json
+++ b/client/package.json
@@ -12,7 +12,8 @@
     "classnames": "^2.5.1",
     "next": "14.2.3",
     "react": "^18",
-    "react-dom": "^18"
+    "react-dom": "^18",
+    "swr": "^2.2.5"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -2,6 +2,7 @@ import Link from "next/link"
 import useSWR from "swr";
 import { Sub } from "../types";
 import axios from "axios";
+import Image from "next/image";
 
 export default function Home() {
 
@@ -23,7 +24,33 @@ export default function Home() {
           </div>
 
           {/* 커뮤니티 리스트 */}
-          <div></div>
+          <div>
+            {topSubs?.map((sub) => (
+              <div
+                key={sub.name}
+                className="flex items-center px-4 py-2 text-xs border-b"
+              >
+                <Link href={`/r/${sub.name}`}>
+                  <span>
+                    <Image
+                      src={sub.imageUrl}
+                      className="rounded-full cursor-pointer"
+                      alt="Sub"
+                      width={24}
+                      height={24}
+                    />
+                  </span>
+                </Link>
+                <Link href={`/r/${sub.name}`}>
+                  <span className='ml-2 font-bold hover:cursor-pointer'>
+                    /r/{sub.name}
+                  </span>
+                </Link>
+                <p className='ml-auto font-md'>{sub.postCount}</p>
+              </div>
+            ))}
+          </div>
+            
           <div className='w-full py-6 text-center'>
             <Link href="/subs/create">
               <span className='w-full p-2 text-center text-white bg-gray-400 rounded'>

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -1,8 +1,31 @@
+import Link from "next/link"
+
 export default function Home() {
   return (
-    <main
-      className="flex min-h-screen flex-col items-center justify-between p-24"
-    >
-    </main>
+    <div className='flex max-w-5xl px-4 pt-5 mx-auto'>
+      {/* 포스트 리스트 */}
+      <div className='w-full md:mr-3 md:w-8/12'>  </div>
+
+      {/* 사이드바 */}
+      <div className='hidden w-4/12 ml-3 md:block'>
+        <div className='bg-white border rounded'>
+          <div className='p-4 border-b'>
+            <p className='text-lg font-semibold text-center'>상위 커뮤니티</p>
+          </div>
+
+          {/* 커뮤니티 리스트 */}
+          <div></div>
+          <div className='w-full py-6 text-center'>
+            <Link href="/subs/create">
+              <span className='w-full p-2 text-center text-white bg-gray-400 rounded'>
+                커뮤니티 만들기
+              </span>
+            </Link>
+          </div>
+          
+        </div>
+      </div>
+
+    </div>
   );
 }

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -1,6 +1,15 @@
 import Link from "next/link"
+import useSWR from "swr";
+import { Sub } from "../types";
+import axios from "axios";
 
 export default function Home() {
+
+  const fetcher = async (url: string) =>
+    await axios.get(url).then(res => res.data);
+  const address = "http://localhost:4000/api/subs/sub/topSubs";
+  const { data: topSubs } = useSWR<Sub[]>(address, fetcher);
+  console.log('topSubs', topSubs)
   return (
     <div className='flex max-w-5xl px-4 pt-5 mx-auto'>
       {/* 포스트 리스트 */}

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -3,9 +3,10 @@ import useSWR from "swr";
 import { Sub } from "../types";
 import axios from "axios";
 import Image from "next/image";
+import { useAuthState } from "../context/auth";
 
 export default function Home() {
-
+  const { authenticated } = useAuthState();
   const fetcher = async (url: string) =>
     await axios.get(url).then(res => res.data);
   const address = "http://localhost:4000/api/subs/sub/topSubs";
@@ -50,15 +51,16 @@ export default function Home() {
               </div>
             ))}
           </div>
-            
-          <div className='w-full py-6 text-center'>
-            <Link href="/subs/create">
-              <span className='w-full p-2 text-center text-white bg-gray-400 rounded'>
-                커뮤니티 만들기
-              </span>
-            </Link>
-          </div>
           
+          {authenticated &&
+            <div className='w-full py-6 text-center'>
+              <Link href="/subs/create">
+                <span className='w-full p-2 text-center text-white bg-gray-400 rounded'>
+                  커뮤니티 만들기
+                </span>
+              </Link>
+            </div>
+          }
         </div>
       </div>
 

--- a/client/src/styles/globals.css
+++ b/client/src/styles/globals.css
@@ -1,33 +1,19 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-:root {
-  --foreground-rgb: 0, 0, 0;
-  --background-start-rgb: 214, 219, 220;
-  --background-end-rgb: 255, 255, 255;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --foreground-rgb: 255, 255, 255;
-    --background-start-rgb: 0, 0, 0;
-    --background-end-rgb: 0, 0, 0;
-  }
-}
-
+html,
 body {
-  color: rgb(var(--foreground-rgb));
-  background: linear-gradient(
-      to bottom,
-      transparent,
-      rgb(var(--background-end-rgb))
-    )
-    rgb(var(--background-start-rgb));
+  padding: 0;
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
+    Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
 }
 
-@layer utilities {
-  .text-balance {
-    text-wrap: balance;
-  }
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+* {
+  box-sizing: border-box;
 }

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -4,3 +4,48 @@ export interface User {
     createdAt: string;
     updatedAt: string;
 }
+
+export interface Sub {
+    createdAt: string;
+    updatedAt: string;
+    name: string;
+    title: string;
+    description: string;
+    imageUrn: string;
+    bannerUrn: string;
+    username: string;
+    posts: Post[];
+    postCount?: string;
+
+    imageUrl: string;
+    bannerUrl: string;
+}
+
+export interface Post {
+    identifier: string;
+    title: string;
+    slug: string;
+    body: string;
+    subName: string;
+    username: string;
+    createdAt: string;
+    updatedAt: string;
+    sub?: Sub;
+
+    url: string;
+    userVote?: number;
+    voteScore?: number;
+    commentCount?: number;
+}
+
+export interface Comment {
+    identifier: string;
+    body: string;
+    username: string;
+    createdAt: string;
+    updatedAt: string;
+    post?: Post;
+
+    userVote: string;
+    voteScore: string;
+}

--- a/server/src/routes/subs.ts
+++ b/server/src/routes/subs.ts
@@ -1,10 +1,8 @@
 import { Request, Response, Router } from "express";
-import jwt from "jsonwebtoken";
 import User from "../entities/User";
 import userMiddleware from "../middlewares/user";
 import authMiddleware from "../middlewares/auth";
 import { isEmpty } from "class-validator";
-import { getRepository } from "typeorm";
 import Sub from "../entities/Sub";
 import { AppDataSource } from "../data-source";
 import Post from "../entities/Post";
@@ -17,10 +15,10 @@ const createSub = async (req: Request, res: Response) => {
         if(isEmpty(name)) errors.name = "이름은 비워둘 수 없습니다.";
         if(isEmpty(title)) errors.title = "제목은 비워둘 수 없습니다.";
         
-        const sub = await getRepository(Sub)    // select data in db using QueryBuilder
+        const sub = await AppDataSource.getRepository(Sub)    // select data in db using QueryBuilder
             .createQueryBuilder("sub")
             .where("lower(sub.name) = :name", { name: name.toLowerCase() })
-            .getOne()
+            .getOne();
 
         if(sub) errors.name = "서브가 이미 존재합니다.";
 


### PR DESCRIPTION
## Overview
- 생성된 커뮤니티 중 상위 커뮤티니들을 우측 바 형태로 메인 페이지에서 보여줌
- 로그인 한 사람은 커뮤니티 만들기 버튼도 같이 보임

## Change Log
1. side bar UI 생성 : `client/src/pages/index.tsx`
   <img src="https://github.com/2018007956/Preddit/assets/48304130/7b3a8c15-6f2b-49e4-8ece-e491d994b0a7" width="600">

2. 상위 커뮤니티 리스트들을 db에서 가져오기 (useSWR 사용)
   1. client에서 npm install swr —save
   2. 백엔드에서 상위 커뮤니티 리스트를 가져오는 topSubs handler 구현
   - console.log 찍어보면 생성된 커뮤니티가 보임
      <img src="https://github.com/2018007956/Preddit/assets/48304130/1c2d6e5c-1361-4cf8-abfb-ef34abfaea88" width="400">
   - pgAdmin4 에서도 확인 가능
      - Linux 설치 명령어 : https://stackoverflow.com/questions/58239607/pgadmin-package-pgadmin4-has-no-installation-candidate
      - postgres 서버 연결 : https://jiurinie.tistory.com/59
         <img src="https://github.com/2018007956/Preddit/assets/48304130/747f310e-aa5a-419c-9112-39c7ce14bcd6" width="600">

3. 리스트 UI 생성 : `client/src/pages/index.tsx`

4. 이미지를 가져오는 도메인 등록 : `client/next.config.mjs`
   - 등록안하면 다음과 같은 에러 발생
      <img src="https://github.com/2018007956/Preddit/assets/48304130/24c3edad-02eb-4929-b716-18593293a116" width="500">

## Result
<img src="https://github.com/2018007956/Preddit/assets/48304130/482d8f31-6cc8-4f65-b2b4-fc7b154b4805" width="650">

## Issue Tags
- Closed: #21 