### PR TITLE
feat: community info page

### DIFF
--- a/client/next.config.mjs
+++ b/client/next.config.mjs
@@ -2,7 +2,7 @@
 const nextConfig = {
   reactStrictMode: true,
   images:{
-    domains: ["www.gravatar.com"]
+    domains: ["www.gravatar.com", "localhost"]
   }
 };
 

--- a/client/src/pages/_app.tsx
+++ b/client/src/pages/_app.tsx
@@ -15,7 +15,7 @@ export default function App({ Component, pageProps }: AppProps) {
 
   return <AuthProvider>
     {!authRoute && <NavBar />}
-    <div className={authRoute ? "" : "pt-12"}>
+    <div className={authRoute ? "" : "pt-16"}>
       <Component {...pageProps} />
     </div>
   </AuthProvider>

--- a/client/src/pages/r/[sub].tsx
+++ b/client/src/pages/r/[sub].tsx
@@ -1,0 +1,26 @@
+import axios from 'axios'
+import { useRouter } from 'next/router';
+import React from 'react'
+import useSWR from 'swr';
+
+const SubPage = () => {
+
+    const fetcher = async (url: string) => {
+        try {
+            const res = await axios.get(url);
+            return res.data;
+        } catch (error: any) {
+            throw error.response.data;
+        }
+    };
+
+    const router = useRouter();
+    const subName = router.query.sub;
+    const { data: sub, error } = useSWR(subName ? `/subs/${subName}` : null, fetcher);
+
+    return (
+    <div>SubPage</div>
+    )
+}
+
+export default SubPage

--- a/client/src/pages/r/[sub].tsx
+++ b/client/src/pages/r/[sub].tsx
@@ -1,11 +1,13 @@
+import { useAuthState } from '@/src/context/auth';
 import axios from 'axios'
 import Image from 'next/image';
 import { useRouter } from 'next/router';
-import React from 'react'
+import React, { ChangeEvent, useEffect, useRef, useState } from 'react'
 import useSWR from 'swr';
 
 const SubPage = () => {
-
+    const [ownSub, setOwnSub] = useState(false);
+    const { authenticated, user } = useAuthState();
     const fetcher = async (url: string) => {
         try {
             const res = await axios.get(url);
@@ -14,17 +16,50 @@ const SubPage = () => {
             throw error.response.data;
         }
     };
-
+    const fileInputRef = useRef<HTMLInputElement>(null);
     const router = useRouter();
     const subName = router.query.sub;
     const { data: sub, error } = useSWR(subName ? `/subs/${subName}` : null, fetcher);
     console.log('sub', sub);
+
+    useEffect(() => {
+        if(!sub) return;
+        setOwnSub(authenticated && user!.username === sub.username);
+    }, [])
+
+    const uploadImage = async (event: ChangeEvent<HTMLInputElement>) => {
+        if(event.target.files === null) return;
+        const file = event.target.files[0];
+
+        const formData = new FormData();
+        formData.append("file", file);
+        formData.append("type", fileInputRef.current!.name);
+
+        try { // Request to Backend
+            await axios.post(`/subs/${sub.name}/upload`, formData, {
+                headers: { "Context-Type": "multipart/form-data" },
+            });
+        } catch (error) {
+            console.log(error);
+        }
+    }
+
+    const openFileInput = (type: string) => {
+        if(!ownSub) return; // 자신이 만든 커뮤니티만 사진 변경 가능
+        const fileInput = fileInputRef.current;
+        if(fileInput) {
+           fileInput.name = type;
+           fileInput.click(); 
+        }
+    }
+
     return (
         <>
             {sub &&
                 <>
                     <div>
-                        {/* 배터 이미지 */}
+                        <input type="file" hidden={true} ref={fileInputRef} onChange={uploadImage}/>
+                        {/* 배너 이미지 */}
                         <div className="bg-gray-400">
                             {sub.bannerUrl ? (
                                 <div
@@ -35,9 +70,13 @@ const SubPage = () => {
                                         backgroundSize: "cover",
                                         backgroundPosition: "center",
                                     }}
+                                    onClick={() => openFileInput("banner")}
                                 ></div>
                             ) : (
-                                <div className="h-20 bg-gray-400"></div>
+                                <div 
+                                    className="h-20 bg-gray-400"
+                                    onClick={() => openFileInput("banner")}
+                                ></div>
                             )}
                         </div>
                         {/* Sub meta data */}
@@ -51,6 +90,7 @@ const SubPage = () => {
                                             width={70}
                                             height={70}
                                             className="rounded-full"
+                                            onClick={() => openFileInput("image")}
                                         />
                                     )}
                                 </div>

--- a/client/src/pages/r/[sub].tsx
+++ b/client/src/pages/r/[sub].tsx
@@ -1,4 +1,5 @@
 import axios from 'axios'
+import Image from 'next/image';
 import { useRouter } from 'next/router';
 import React from 'react'
 import useSWR from 'swr';
@@ -17,9 +18,58 @@ const SubPage = () => {
     const router = useRouter();
     const subName = router.query.sub;
     const { data: sub, error } = useSWR(subName ? `/subs/${subName}` : null, fetcher);
-
+    console.log('sub', sub);
     return (
-    <div>SubPage</div>
+        <>
+            {sub &&
+                <>
+                    <div>
+                        {/* 배터 이미지 */}
+                        <div className="bg-gray-400">
+                            {sub.bannerUrl ? (
+                                <div
+                                    className='h-56'
+                                    style={{
+                                        backgroundImage: `url(${sub.bannerUrl})`,
+                                        backgroundRepeat: "no-repeat",
+                                        backgroundSize: "cover",
+                                        backgroundPosition: "center",
+                                    }}
+                                ></div>
+                            ) : (
+                                <div className="h-20 bg-gray-400"></div>
+                            )}
+                        </div>
+                        {/* Sub meta data */}
+                        <div className='h-20 bg-white'>
+                            <div className='relative flex max-w-5xl px-5 mx-auto'>
+                                <div className='absolute' style={{ top: -15 }}>
+                                    {sub.imageUrl && (
+                                        <Image
+                                            src={sub.imageUrl}
+                                            alt="커뮤니티 이미지"
+                                            width={70}
+                                            height={70}
+                                            className="rounded-full"
+                                        />
+                                    )}
+                                </div>
+                                <div className='pt-1 pl-24'>
+                                    <div className='flex items-center'>
+                                        <h1 className='text-3xl font-bold'>{sub.title}</h1>
+                                    </div>
+                                    <p className='font-bold text-gray-400 text-small'>
+                                        /r/{sub.name}
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    {/* Posts & Sidebar */}
+                    <div className='flex max-w-5xl px-4 pt-5 mx-auto'></div>
+                </>
+            }
+        </>
     )
 }
 

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 build/
 tmp/
 temp/
+public/

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -16,6 +16,7 @@
             "express": "^4.19.2",
             "jsonwebtoken": "^9.0.2",
             "morgan": "^1.10.0",
+            "multer": "^1.4.5-lts.1",
             "nodemon": "^3.1.3",
             "pg": "^8.4.0",
             "reflect-metadata": "^0.1.13",
@@ -28,6 +29,7 @@
             "@types/express": "^4.17.21",
             "@types/jsonwebtoken": "^9.0.6",
             "@types/morgan": "^1.9.9",
+            "@types/multer": "^1.4.11",
             "@types/node": "^16.18.98",
             "ts-node": "^10.9.1",
             "typescript": "^4.5.2"
@@ -221,6 +223,15 @@
             "@types/node": "*"
          }
       },
+      "node_modules/@types/multer": {
+         "version": "1.4.11",
+         "resolved": "https://registry.npmjs.org/@types/multer/-/multer-1.4.11.tgz",
+         "integrity": "sha512-svK240gr6LVWvv3YGyhLlA+6LRRWA4mnGIU7RcNmgjBYFl6665wcXrRfxGp5tEPVHUNm5FMcmq7too9bxCwX/w==",
+         "dev": true,
+         "dependencies": {
+            "@types/express": "*"
+         }
+      },
       "node_modules/@types/node": {
          "version": "16.18.98",
          "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.98.tgz",
@@ -342,6 +353,11 @@
          "engines": {
             "node": ">= 6.0.0"
          }
+      },
+      "node_modules/append-field": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+         "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw=="
       },
       "node_modules/arg": {
          "version": "4.1.3",
@@ -475,6 +491,22 @@
          "version": "1.0.1",
          "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
          "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+      },
+      "node_modules/buffer-from": {
+         "version": "1.1.2",
+         "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+         "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+      },
+      "node_modules/busboy": {
+         "version": "1.6.0",
+         "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+         "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+         "dependencies": {
+            "streamsearch": "^1.1.0"
+         },
+         "engines": {
+            "node": ">=10.16.0"
+         }
       },
       "node_modules/bytes": {
          "version": "3.1.2",
@@ -754,6 +786,20 @@
          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
          "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
       },
+      "node_modules/concat-stream": {
+         "version": "1.6.2",
+         "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+         "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+         "engines": [
+            "node >= 0.8"
+         ],
+         "dependencies": {
+            "buffer-from": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.2.2",
+            "typedarray": "^0.0.6"
+         }
+      },
       "node_modules/content-disposition": {
          "version": "0.5.4",
          "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -805,6 +851,11 @@
          "version": "1.0.6",
          "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
          "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+      },
+      "node_modules/core-util-is": {
+         "version": "1.0.3",
+         "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+         "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
       },
       "node_modules/cors": {
          "version": "2.8.5",
@@ -1355,6 +1406,11 @@
             "node": ">=0.12.0"
          }
       },
+      "node_modules/isarray": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+         "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+      },
       "node_modules/isexe": {
          "version": "2.0.0",
          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -1533,6 +1589,14 @@
             "node": "*"
          }
       },
+      "node_modules/minimist": {
+         "version": "1.2.8",
+         "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+         "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
+         }
+      },
       "node_modules/minipass": {
          "version": "7.1.2",
          "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
@@ -1585,6 +1649,34 @@
          "version": "2.0.0",
          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+      },
+      "node_modules/multer": {
+         "version": "1.4.5-lts.1",
+         "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.5-lts.1.tgz",
+         "integrity": "sha512-ywPWvcDMeH+z9gQq5qYHCCy+ethsk4goepZ45GLD63fOu0YcNecQxi64nDs3qluZB+murG3/D4dJ7+dGctcCQQ==",
+         "dependencies": {
+            "append-field": "^1.0.0",
+            "busboy": "^1.0.0",
+            "concat-stream": "^1.5.2",
+            "mkdirp": "^0.5.4",
+            "object-assign": "^4.1.1",
+            "type-is": "^1.6.4",
+            "xtend": "^4.0.0"
+         },
+         "engines": {
+            "node": ">= 6.0.0"
+         }
+      },
+      "node_modules/multer/node_modules/mkdirp": {
+         "version": "0.5.6",
+         "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+         "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+         "dependencies": {
+            "minimist": "^1.2.6"
+         },
+         "bin": {
+            "mkdirp": "bin/cmd.js"
+         }
       },
       "node_modules/mz": {
          "version": "2.7.0",
@@ -1876,6 +1968,11 @@
             "node": ">=0.10.0"
          }
       },
+      "node_modules/process-nextick-args": {
+         "version": "2.0.1",
+         "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+         "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+      },
       "node_modules/proxy-addr": {
          "version": "2.0.7",
          "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -1928,6 +2025,25 @@
          "engines": {
             "node": ">= 0.8"
          }
+      },
+      "node_modules/readable-stream": {
+         "version": "2.3.8",
+         "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+         "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+         "dependencies": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+         }
+      },
+      "node_modules/readable-stream/node_modules/safe-buffer": {
+         "version": "5.1.2",
+         "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+         "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
       },
       "node_modules/readdirp": {
          "version": "3.6.0",
@@ -2137,6 +2253,27 @@
             "node": ">= 0.8"
          }
       },
+      "node_modules/streamsearch": {
+         "version": "1.1.0",
+         "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+         "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+         "engines": {
+            "node": ">=10.0.0"
+         }
+      },
+      "node_modules/string_decoder": {
+         "version": "1.1.1",
+         "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+         "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+         "dependencies": {
+            "safe-buffer": "~5.1.0"
+         }
+      },
+      "node_modules/string_decoder/node_modules/safe-buffer": {
+         "version": "5.1.2",
+         "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+         "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      },
       "node_modules/string-width": {
          "version": "5.1.2",
          "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
@@ -2342,6 +2479,11 @@
             "node": ">= 0.6"
          }
       },
+      "node_modules/typedarray": {
+         "version": "0.0.6",
+         "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+         "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
+      },
       "node_modules/typeorm": {
          "version": "0.3.20",
          "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.20.tgz",
@@ -2498,6 +2640,11 @@
          "engines": {
             "node": ">= 0.8"
          }
+      },
+      "node_modules/util-deprecate": {
+         "version": "1.0.2",
+         "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+         "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
       },
       "node_modules/utils-merge": {
          "version": "1.0.1",

--- a/server/package.json
+++ b/server/package.json
@@ -19,6 +19,7 @@
       "express": "^4.19.2",
       "jsonwebtoken": "^9.0.2",
       "morgan": "^1.10.0",
+      "multer": "^1.4.5-lts.1",
       "nodemon": "^3.1.3",
       "pg": "^8.4.0",
       "reflect-metadata": "^0.1.13",
@@ -31,6 +32,7 @@
       "@types/express": "^4.17.21",
       "@types/jsonwebtoken": "^9.0.6",
       "@types/morgan": "^1.9.9",
+      "@types/multer": "^1.4.11",
       "@types/node": "^16.18.98",
       "ts-node": "^10.9.1",
       "typescript": "^4.5.2"

--- a/server/src/entities/Entity.ts
+++ b/server/src/entities/Entity.ts
@@ -1,3 +1,4 @@
+import { instanceToPlain } from "class-transformer";
 import { BaseEntity, CreateDateColumn, PrimaryGeneratedColumn, UpdateDateColumn } from "typeorm";
 
 export default abstract class Entity extends BaseEntity {
@@ -9,4 +10,8 @@ export default abstract class Entity extends BaseEntity {
 
     @UpdateDateColumn()
     updatedAt: Date;
+
+    toJSON() {
+        return instanceToPlain(this);   // Entity에서 @Expose 해준 것들을 프론트에서 가져올 수 있음
+    }
 }

--- a/server/src/routes/subs.ts
+++ b/server/src/routes/subs.ts
@@ -71,7 +71,8 @@ const createSub = async (req: Request, res: Response) => {
 
 const topSubs = async (_: Request, res: Response) => {
     try {
-        const imageUrlExp = `COALESCE(s."imageUrn", 'https://www.gravatar.com/avatar?d=mp&f=y')`;
+        const imageUrlExp = `COALESCE('${process.env.APP_URL}/images/' || s."imageUrn", 
+                                        'https://www.gravatar.com/avatar?d=mp&f=y')`;
         const subs = await AppDataSource
             .createQueryBuilder()
             .select(`s.title, s.name, ${imageUrlExp} as "imageUrl", count(p.id) as "postCount"`)

--- a/server/src/routes/subs.ts
+++ b/server/src/routes/subs.ts
@@ -1,4 +1,4 @@
-import { Request, Response, Router } from "express";
+import { NextFunction, Request, Response, Router } from "express";
 import User from "../entities/User";
 import userMiddleware from "../middlewares/user";
 import authMiddleware from "../middlewares/auth";
@@ -6,6 +6,10 @@ import { isEmpty } from "class-validator";
 import Sub from "../entities/Sub";
 import { AppDataSource } from "../data-source";
 import Post from "../entities/Post";
+import multer, { FileFilterCallback } from "multer";
+import path from "path";
+import { unlinkSync } from "fs";
+import { makeId } from "../utils/helpers";
 
 const getSub = async (req: Request, res: Response) => {
     const name = req.params.name;
@@ -84,10 +88,89 @@ const topSubs = async (_: Request, res: Response) => {
     }
 }
 
+const ownSub = async (req: Request, res: Response, next: NextFunction) => {
+    const user: User = res.locals.user;
+
+    try {
+        const sub = await Sub.findOneOrFail({ where: { name: req.params.name } });
+
+        if(sub.username !== user.username) {
+            return res.status(403).json({ error: "이 커뮤니티를 소유하고 있지 않습니다." });
+        }
+
+        res.locals.sub = sub;
+
+        return next();
+    } catch (error) {
+        console.log(error);
+        return res.status(500).json({ error: "문제가 발생했습니다." });        
+    }
+}
+
+const upload = multer({
+    storage: multer.diskStorage({
+        destination: "public/images",
+        filename: (_, file, callback) => {
+            const name = makeId(10);
+            callback(null, name + path.extname(file.originalname)); // imagename + .png
+        },
+    }),
+    fileFilter: (_, file: any, callback: FileFilterCallback) => {
+        if(file.mimetype == "image/jpeg" || file.mimetype == "image/png") {
+            callback(null, true);
+        } else {
+            callback(new Error("이미지가 아닙니다."));
+        }
+    },
+})
+
+const uploadSubImage = async (req: Request, res: Response) => {
+    const sub: Sub = res.locals.sub;
+    try {
+        const type = req.body.type;
+
+        // 지정된 파일 유형이 아니면 업로드 된 파일 삭제
+        if(type !== "image" && type !== "banner") {
+            if(!req.file?.path) {
+                return res.status(400).json({ error: "유효하지 않은 파일" });
+            }
+
+            unlinkSync(req.file.path);
+            return res.status(400).json({ error: "잘못된 유형" });
+        }
+
+        let oldImageUrn: string = "";
+
+        if(type === "image") {
+            // 사용중인 Urn을 저장 (이전 파일을 아래서 삭제하기 위함)
+            oldImageUrn = sub.imageUrn || "";
+            // 새로운 파일 이름을 Urn으로 넣어줌
+            sub.imageUrn = req.file?.filename || "";
+        } else if(type === "banner") {
+            oldImageUrn = sub.bannerUrn || "";
+            sub.bannerUrn = req.file?.filename || "";
+        }
+        await sub.save();
+
+        // 사용하지 않는 이미지 파일 삭제
+        if(oldImageUrn !== "") {
+            // 데이터베이스는 파일 이름일 뿐이므로 개체 경로 접두사를 직접 추가해야 함
+            const fullFileName = path.resolve(process.cwd(), "public", "images", oldImageUrn);
+
+            unlinkSync(fullFileName);
+        }
+
+        return res.json(sub);
+    } catch (error) {
+        console.log(error);
+        return res.status(500).json({ error: "문제가 발생했습니다." });
+    }
+}
+
 const router = Router();
 
 router.get("/:name", userMiddleware, getSub);
 router.post("/", userMiddleware, authMiddleware, createSub);   // call handler
 router.get("/sub/topSubs", topSubs);
-
+router.post("/:name/upload", userMiddleware, authMiddleware, ownSub, upload.single("file"), uploadSubImage);
 export default router;

--- a/server/src/routes/subs.ts
+++ b/server/src/routes/subs.ts
@@ -7,6 +7,20 @@ import Sub from "../entities/Sub";
 import { AppDataSource } from "../data-source";
 import Post from "../entities/Post";
 
+const getSub = async (req: Request, res: Response) => {
+    const name = req.params.name;
+
+    try {
+        const sub = await Sub.findOneByOrFail({ name });
+
+        // 포스트를 생성한 후에 해당 sub에 속하는 포스트 정보들을 넣어주기
+
+        return res.json(sub);
+    } catch (error) {
+        return res.status(404).json({ error: "커뮤니티를 찾을 수 없습니다." });
+    }
+}
+
 const createSub = async (req: Request, res: Response) => {
     const {name, title, description} = req.body;
 
@@ -72,6 +86,7 @@ const topSubs = async (_: Request, res: Response) => {
 
 const router = Router();
 
+router.get("/:name", userMiddleware, getSub);
 router.post("/", userMiddleware, authMiddleware, createSub);   // call handler
 router.get("/sub/topSubs", topSubs);
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -24,6 +24,8 @@ app.get("/", (_, res) => res.send("running"));
 app.use("/api/auth", authRoutes)
 app.use("/api/subs", subRoutes)
 
+app.use(express.static("public"));
+
 let port = 4000;
 app.listen(port, async () => {
     console.log(`server running at http://localhost:${port}`);


### PR DESCRIPTION
## Overview
- 커뮤니티 상세 페이지
  - 타이틀, 커뮤니티 이름 노출
  - 프로필, 배너 이미지 업로드 기능 구현

## Change Log
1. 상세 페이지 데이터 가져오기
   - `client/src/pages/r/[sub].tsx` useSWR 사용, fetcher로 백엔드에서 커뮤니티 데이터 가져오기
   - `server/src/routes/subs.ts` getSub

2. 상세 페이지 UI : `client/src/pages/r/[sub].tsx`
   - 배너, 커뮤니티 메타 데이터, (포스트, 사이드바 -> 추후 구현)

- **[문제 상황]** 프론트에서 imageUrl, bannerUrl을 못가져옴
    <img src="https://github.com/2018007956/Preddit/assets/48304130/bd68bdd4-e5b2-490b-b444-a8e288022510" width="700">
    **해결** : Base Entity에 instanceToPlain 추가
    <img src="https://github.com/2018007956/Preddit/assets/48304130/580ce5f3-cdcb-4289-b5f0-115773698e6a" width="550">

3. 이미지 업로드 기능 만들기 : `client/src/pages/r/[sub].tsx` openFileInput, uploadImage (useRef 사용)
   - 자신의 커뮤니티 일 때만 클릭 가능

4. 서버에서 핸들러 구현 : `server/src/routes/subs.ts` 
   - ownSub : 커뮤니티 소유자인지 확인
   - upload : 업로드한 이미지 로컬 저장
     - multer 모듈 설치 - 업로드된 이미지를 로컬에 저장하기 위해 필요한 모듈  
        > npm install multer --save
        > npm i --save-dev @types/multer 
     - 저장 경로 : public/images 
   - uploadSubImage : 이미지를 바꾸는 경우, 기존 이미지를 삭제하고 새로운 파일 저장

5. public 폴더에 있는 파일들을 클라이언트에게 제공할 수 있도록 설정 필요 : `server/src/server.ts`
    - `app.use(express.static("public"));`

## Result
<img src="https://github.com/2018007956/Preddit/assets/48304130/1effa46b-22d4-4fde-bf76-67fe41cac3f1" width="500">

## Issue Tags
- Closed: #23 
- See also: #25 