### PR TITLE
feat: side bar in community info page

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "classnames": "^2.5.1",
+        "dayjs": "^1.11.11",
         "next": "14.2.3",
         "react": "^18",
         "react-dom": "^18",
@@ -2358,6 +2359,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.11",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.11.tgz",
+      "integrity": "sha512-okzr3f11N6WuqYtZSvm+F776mB41wRZMhKP+hc34YdW+KmtYYK9iqvHSwo2k9FEH3fhGXvOPV6yz2IcSrfRUDg=="
     },
     "node_modules/debug": {
       "version": "4.3.5",

--- a/client/package.json
+++ b/client/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "classnames": "^2.5.1",
+    "dayjs": "^1.11.11",
     "next": "14.2.3",
     "react": "^18",
     "react-dom": "^18",

--- a/client/src/components/Sidebar.tsx
+++ b/client/src/components/Sidebar.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import { Sub } from '../types'
+type Props = {
+    sub: Sub
+}
+
+const Sidebar = ({ sub }: Props) => {
+    return (
+      <div>Sidebar</div>
+    )
+  }
+  
+  export default Sidebar

--- a/client/src/components/Sidebar.tsx
+++ b/client/src/components/Sidebar.tsx
@@ -1,13 +1,45 @@
 import React from 'react'
+import { useAuthState } from '../context/auth'
 import { Sub } from '../types'
+import Link from 'next/link'
+import dayjs from 'dayjs'
 type Props = {
     sub: Sub
 }
 
 const Sidebar = ({ sub }: Props) => {
+    const { authenticated } = useAuthState();
     return (
-      <div>Sidebar</div>
+    <div className='hidden w-4/12 ml-3 md:block'>
+            <div className='bg-white border rounded'>
+                <div className='p-3 bg-gray-400 rounded-t'>
+                    <p className='font-semibold text-white'>커뮤니티에 대해서</p>
+                </div>
+                <div className='p-3'>
+                    <p className='mb-3 text-base'>{sub?.description}</p>
+                    <div className='flex mb-3 text-sm font-medium'>
+                        <div className='w-1/2'>
+                            <p>100</p>
+                            <p>멤버</p>
+                        </div>
+                    </div>
+                    <p className='my-3'>
+                        {dayjs(sub?.createdAt).format("D MMM YYYY")}
+                    </p>
+
+                    {authenticated && (
+                        <div className='mx-0 my-2'>
+                            <Link href={`/r/${sub.name}/create`}>
+                                <span className="w-full p-2 text-sm text-white bg-gray-400 rounded">
+                                    포스트 생성
+                                </span>
+                            </Link>
+                        </div>
+                    )}
+                </div>
+            </div>
+        </div>
     )
-  }
-  
-  export default Sidebar
+}
+
+export default Sidebar

--- a/client/src/pages/r/[sub].tsx
+++ b/client/src/pages/r/[sub].tsx
@@ -1,3 +1,4 @@
+import Sidebar from '@/src/components/Sidebar';
 import { useAuthState } from '@/src/context/auth';
 import axios from 'axios'
 import Image from 'next/image';
@@ -106,7 +107,10 @@ const SubPage = () => {
                         </div>
                     </div>
                     {/* Posts & Sidebar */}
-                    <div className='flex max-w-5xl px-4 pt-5 mx-auto'></div>
+                    <div className='flex max-w-5xl px-4 pt-5 mx-auto'>
+                        <div className='w-full md:mr-3 md:w-8/12'></div>
+                        <Sidebar sub={sub} />
+                    </div>
                 </>
             }
         </>


### PR DESCRIPTION
## Overview
- 커뮤니티 상세 페이지에 커뮤니티 정보와 포스트 생성 버튼이 있는 사이드 바 구현

## Change Log
1. 사이드 바 컴포넌트 생성 : `client/src/components/Sidebar.tsx`
2. 사이드 바 컴포넌트 import : `client/src/pages/r/[sub].tsx`
3. 사이드 바 UI 생성 : `client/src/components/Sidebar.tsx`
4. 시간을 위한 모듈 설치
   > npm install dayjs --save
   - 적용 전
      - 코드 : sub?.createdAt
      - 출력 : 2024-07-01T22:58:54.438Z
   - 적용 후
      - 코드 : dayjs(sub?.createdAt).format("D MMM YYYY")
      - 출력 : 2 Jul 2024

## Result
<img src="https://github.com/2018007956/Preddit/assets/48304130/081aa632-9bb8-4c83-abd0-1ab05db69052" width="600">

## To be updated
- 멤버 수가 하드 코딩 되어있는데, 추후 동적 변환 필요

## Issue Tags
- Closed: #26 