### PR TITLE
feat: post create page

### DIFF
--- a/client/src/pages/r/[sub]/create.tsx
+++ b/client/src/pages/r/[sub]/create.tsx
@@ -1,0 +1,43 @@
+import React from 'react'
+
+const PostCreate = () => {
+    return (
+    <div className='flex flex-col justify-center pt-16'>
+            <div className='w-10/12 mx-auto md:w-96'>
+                <div className='p-4 bg-white rounded'>
+                    <h1 className='mb-3 text-lg'>포스트 생성하기</h1>
+                    <form>
+                        <div className='relative mb-2'>
+                            <input
+                                type="text"
+                                className="w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:border-blue-500"
+                                placeholder="제목"
+                                maxLength={20}
+                            />
+                            <div
+                                style={{ top: 10, right: 10 }}
+                                className="absolute mb-2 text-sm text-gray-400 select-none"
+                            >
+                                        /20
+                            </div>
+                        </div>
+                        <textarea
+                            rows={4}
+                            placeholder="설명"
+                            className='w-full p-3 border border-gray-300 rounded focus:outline-none focus:border-blue-500'
+                        />
+                        <div className='flex justify-end'>
+                            <button
+                                className='px-4 py-1 text-sm font-semibold text-white bg-gray-400 border rounded'
+                            >
+                                생성하기
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    )
+}
+
+export default PostCreate

--- a/client/src/pages/r/[sub]/create.tsx
+++ b/client/src/pages/r/[sub]/create.tsx
@@ -1,20 +1,47 @@
+import { Post } from '@/src/types';
 import axios from 'axios'
 import { GetServerSideProps } from 'next'
-import React from 'react'
+import { useRouter } from 'next/router';
+import React, { FormEvent, useState } from 'react'
 
 const PostCreate = () => {
+    const [title, setTitle] = useState("");
+    const [body, setBody] = useState("");
+    const router = useRouter();
+    const { sub: subName } = router.query;
+
+    const submitPost = async (e: FormEvent) => {
+        e.preventDefault();
+
+        if (title.trim() === "" || !subName) return;
+
+        try {
+            const { data: post } = await axios.post<Post>("/posts", {
+                title: title.trim(),
+                body,
+                sub: subName
+            });
+
+            router.push(`/r/${subName}/${post.identifier}/${post.slug}`);
+        } catch (error) {
+            console.log(error);
+        }
+    }
+    
     return (
     <div className='flex flex-col justify-center pt-16'>
             <div className='w-10/12 mx-auto md:w-96'>
                 <div className='p-4 bg-white rounded'>
                     <h1 className='mb-3 text-lg'>포스트 생성하기</h1>
-                    <form>
+                    <form onSubmit={submitPost}>
                         <div className='relative mb-2'>
                             <input
                                 type="text"
                                 className="w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:border-blue-500"
                                 placeholder="제목"
                                 maxLength={20}
+                                value={title}
+                                onChange={(e) => setTitle(e.target.value)}
                             />
                             <div
                                 style={{ top: 10, right: 10 }}
@@ -27,10 +54,13 @@ const PostCreate = () => {
                             rows={4}
                             placeholder="설명"
                             className='w-full p-3 border border-gray-300 rounded focus:outline-none focus:border-blue-500'
+                            value={body}
+                            onChange={(e) => setBody(e.target.value)}
                         />
                         <div className='flex justify-end'>
                             <button
                                 className='px-4 py-1 text-sm font-semibold text-white bg-gray-400 border rounded'
+                                disabled={title.trim().length === 0}
                             >
                                 생성하기
                             </button>

--- a/client/src/pages/r/[sub]/create.tsx
+++ b/client/src/pages/r/[sub]/create.tsx
@@ -1,3 +1,5 @@
+import axios from 'axios'
+import { GetServerSideProps } from 'next'
 import React from 'react'
 
 const PostCreate = () => {
@@ -41,3 +43,17 @@ const PostCreate = () => {
 }
 
 export default PostCreate
+
+export const getServerSideProps: GetServerSideProps = async ({ req, res }) => {
+    try {
+        const cookie = req.headers.cookie;
+        if (!cookie) throw new Error("쿠키가 없습니다.");
+
+        await axios.get("/auth/me", { headers: { cookie } });
+
+        return { props: {} };
+    } catch (error) {
+        res.writeHead(307, { Location: "/login" }).end();
+        return { props: {} };
+    }
+}

--- a/server/src/routes/posts.ts
+++ b/server/src/routes/posts.ts
@@ -1,0 +1,34 @@
+import { Request, Response, Router } from "express";
+import userMiddleware from '../middlewares/user';
+import authMiddleware from '../middlewares/auth';
+import Sub from "../entities/Sub";
+import Post from "../entities/Post";
+
+const createPost = async (req: Request, res: Response) => {
+    const { title, body, sub } = req.body;
+    if (title.trim() === "") {
+        return res.status(400).json({ title: "제목은 비워둘 수 없습니다." });
+    }
+
+    const user = res.locals.user;
+
+    try {
+        const subRecord = await Sub.findOneByOrFail({ name: sub });
+        const post = new Post();
+        post.title = title;
+        post.body = body;
+        post.user = user;
+        post.sub = subRecord;
+        
+        await post.save();
+        
+        return res.json(post);
+    } catch (error) {
+        console.log(error);
+        return res.status(500).json({ error: "문제가 발생했습니다." });
+    }
+}
+
+const router = Router();
+router.post("/", userMiddleware, authMiddleware, createPost);
+export default router;

--- a/server/src/routes/subs.ts
+++ b/server/src/routes/subs.ts
@@ -16,8 +16,16 @@ const getSub = async (req: Request, res: Response) => {
 
     try {
         const sub = await Sub.findOneByOrFail({ name });
-
+        
         // 포스트를 생성한 후에 해당 sub에 속하는 포스트 정보들을 넣어주기
+        const posts = await Post.find({
+            where: { subName: sub.name },
+            order: { createdAt: "DESC" },
+            relations: ["comments", "votes"]
+        });
+
+        sub.posts = posts;
+        console.log("posts", posts)
 
         return res.json(sub);
     } catch (error) {

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1,8 +1,11 @@
 import express from "express";
 import morgan from "morgan";
 import { AppDataSource } from "./data-source"
+
 import authRoutes from "./routes/auth";
 import subRoutes from "./routes/subs";
+import postRoutes from "./routes/posts";
+
 import cors from 'cors';
 import dotenv from 'dotenv';
 import cookieParser from "cookie-parser";
@@ -23,6 +26,7 @@ dotenv.config();
 app.get("/", (_, res) => res.send("running"));
 app.use("/api/auth", authRoutes)
 app.use("/api/subs", subRoutes)
+app.use("/api/posts", postRoutes)
 
 app.use(express.static("public"));
 


### PR DESCRIPTION
## Overview
- 포스트 생성하는 페이지 구현
  - 로그인 된 유저만 접근 가능 
- 커뮤니티 상세 페이지에서 생성한 포스트들을 볼 수 있도록 기능 구현

## Change Log
1. UI 생성 : `client/src/pages/r/[sub]/create.tsx`
   <img src="https://github.com/2018007956/Preddit/assets/48304130/bd53629c-ea9a-4a72-88f7-60a4abc18cb0" width="600">
2. 로그인 안하고 /r/[sub]/create 페이지에 접근하면 Redirect /login : `client/src/pages/r/[sub]/create.tsx` getServerSideProps
   - 물론 로그인 안 했을 때 포스트 생성 버튼 안보임, 링크 접속 시 제한 기능
3. 기능 생성
   - 버튼 눌렀을 때 백엔드 요청 보내기 : `client/src/pages/r/[sub]/create.tsx` submitPost
   - api 생성 : `server/src/routes/posts.ts` createPost
   - getSub handler 에 posts 데이터 추가

## Result
- 커뮤니티 상세 페이지(`/r/[sub]`)에서 개발자 도구 열어보면 posts 들어와 있는 것 확인 가능
   <img src="https://github.com/2018007956/Preddit/assets/48304130/0f49a6c0-051e-4e45-b35a-4b75b49eaf55" width="600">

## Issue Tags
- Closed: #28 