### PR TITLE
feat: post cards in community info page

### DIFF
--- a/client/src/components/PostCard.tsx
+++ b/client/src/components/PostCard.tsx
@@ -4,6 +4,9 @@ import { FaArrowDown, FaArrowUp } from 'react-icons/fa6'
 import Link from 'next/link'
 import Image from 'next/image'
 import dayjs from 'dayjs'
+import { useAuthState } from '../context/auth'
+import axios from 'axios'
+import { useRouter } from 'next/router'
 
 interface PostCardProps {
     post: Post
@@ -12,81 +15,94 @@ interface PostCardProps {
 const PostCard = ({ post: {
     identifier, slug, title, body, subName, createdAt, voteScore, userVote, commentCount, url, username, sub
 } }: PostCardProps) => {
-  return (
-    <div
-        className='flex mb-4 bg-white rounded'
-        id={identifier}
-    >
-        {/* Vote */}
-        <div className="flex-shrink-0 w-10 py-2 text-center rounded-l">
-            {/* 좋아요 */}
-            <div
-                className="flex justify-center w-6 mx-auto text-gray-400 rounded cursor-pointer hover:bg-gray-300 hover:text-red-500"
-                // onClick={() => vote(1)}
-            >
-                {userVote === 1 ?
-                    <FaArrowUp className="text-red-500" />
-                    : <FaArrowUp />
-                }
+    const { authenticated } = useAuthState()
+    const router = useRouter()
+    const vote = async (value: number) => {
+        if (!authenticated) router.push('/login');
+        
+        if (value === userVote) value = 0;   // 선택 해제
+
+        try {
+            await axios.post('/votes', { identifier, slug, value });
+        } catch (error) {
+            console.log(error);
+        }        
+    }
+    return (
+        <div
+            className='flex mb-4 bg-white rounded'
+            id={identifier}
+        >
+            {/* Vote */}
+            <div className="flex-shrink-0 w-10 py-2 text-center rounded-l">
+                {/* 좋아요 */}
+                <div
+                    className="flex justify-center w-6 mx-auto text-gray-400 rounded cursor-pointer hover:bg-gray-300 hover:text-red-500"
+                    onClick={() => vote(1)}
+                >
+                    {userVote === 1 ?
+                        <FaArrowUp className="text-red-500" />
+                        : <FaArrowUp />
+                    }
+                </div>
+                <p className="text-xs font-bold">{voteScore}</p>
+                {/* 싫어요 */}
+                <div
+                    className="flex justify-center w-6 mx-auto text-gray-400 rounded cursor-pointer hover:bg-gray-300 hover:text-blue-500"
+                    onClick={() => vote(-1)}
+                >
+                    {userVote === -1 ?
+                        <FaArrowDown className="text-blue-500" />
+                        : <FaArrowDown />
+                    }
+                </div>
             </div>
-            <p className="text-xs font-bold">{voteScore}</p>
-            {/* 싫어요 */}
-            <div
-                className="flex justify-center w-6 mx-auto text-gray-400 rounded cursor-pointer hover:bg-gray-300 hover:text-blue-500"
-                // onClick={() => vote(-1)}
-            >
-                {userVote === -1 ?
-                    <FaArrowDown className="text-blue-500" />
-                    : <FaArrowDown />
-                }
+            {/* 포스트 데이터 부분 */}
+            <div className="w-full p-2">
+                {/* <div className='flex items-center'>
+                    <Link href={`/r/${subName}`}>
+                        <Image
+                            src={sub!.imageUrl}
+                            alt="sub"
+                            className='rounded-full cursor-pointer'
+                            width={12}
+                            height={12}
+                        />
+                    </Link>
+                    <Link href={`/r/${subName}`}>
+                        <a className="ml-2 text-xs font-bold cursor-pointer hover:underline">
+                            /r/{subName}
+                        </a>
+                    </Link>
+                    <span className="mx-1 text-xs text-gray-400">•</span>
+                </div> */}
+
+                <p className="text-xs text-gray-400">
+                    Posted by
+                    <Link href={`/u/${username}`}>
+                        <span className="mx-1 hover:underline">/u/{username}</span>
+                    </Link>
+                    <Link href={url}>
+                        <span className='mx-1 hover:underline'>
+                            {dayjs(createdAt).format('YYYY-MM-DD HH:mm')}
+                        </span>
+                    </Link>
+                </p>
+                
+                <Link href={url}>
+                    <span className="my-1 text-lg font-medium">{title}</span>
+                </Link>
+                {body && <p className="my-1 text-sm">{body}</p>}
+                <div className="flex">
+                    <Link href={url}>
+                        <i className="mr-1 fas fa-comment-alt fa-xs"></i>
+                        <span>{commentCount}</span>
+                    </Link>
+
+                </div>
             </div>
         </div>
-        {/* 포스트 데이터 부분 */}
-        <div className="w-full p-2">
-            {/* <div className='flex items-center'>
-                <Link href={`/r/${subName}`}>
-                    <Image
-                        src={sub!.imageUrl}
-                        alt="sub"
-                        className='rounded-full cursor-pointer'
-                        width={12}
-                        height={12}
-                    />
-                </Link>
-                <Link href={`/r/${subName}`}>
-                    <a className="ml-2 text-xs font-bold cursor-pointer hover:underline">
-                        /r/{subName}
-                    </a>
-                </Link>
-                <span className="mx-1 text-xs text-gray-400">•</span>
-            </div> */}
-
-            <p className="text-xs text-gray-400">
-                Posted by
-                <Link href={`/u/${username}`}>
-                    <span className="mx-1 hover:underline">/u/{username}</span>
-                </Link>
-                <Link href={url}>
-                    <span className='mx-1 hover:underline'>
-                        {dayjs(createdAt).format('YYYY-MM-DD HH:mm')}
-                    </span>
-                </Link>
-            </p>
-            
-            <Link href={url}>
-                <span className="my-1 text-lg font-medium">{title}</span>
-            </Link>
-            {body && <p className="my-1 text-sm">{body}</p>}
-            <div className="flex">
-                <Link href={url}>
-                    <i className="mr-1 fas fa-comment-alt fa-xs"></i>
-                    <span>{commentCount}</span>
-                </Link>
-
-            </div>
-        </div>
-    </div>
-  )
+    )
 }
 
 export default PostCard

--- a/client/src/components/PostCard.tsx
+++ b/client/src/components/PostCard.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import { Post } from '../types'
+
+interface PostCardProps {
+    post: Post
+}
+
+const PostCard = ({ post: {
+    identifier, slug, title, body, subName, createdAt, voteScore, userVote, commentCount, url, username, sub
+} }: PostCardProps) => {
+  return (
+    <div>PostCard</div>
+  )
+}
+
+export default PostCard

--- a/client/src/components/PostCard.tsx
+++ b/client/src/components/PostCard.tsx
@@ -10,11 +10,26 @@ import { useRouter } from 'next/router'
 
 interface PostCardProps {
     post: Post
+    subMutate: () => void
 }
 
-const PostCard = ({ post: {
-    identifier, slug, title, body, subName, createdAt, voteScore, userVote, commentCount, url, username, sub
-} }: PostCardProps) => {
+const PostCard = ({ 
+    post: {
+        identifier, 
+        slug, 
+        title, 
+        body, 
+        subName, 
+        createdAt, 
+        voteScore, 
+        userVote, 
+        commentCount, 
+        url, 
+        username, 
+        sub
+    },
+    subMutate
+ }: PostCardProps) => {
     const { authenticated } = useAuthState()
     const router = useRouter()
     const vote = async (value: number) => {
@@ -24,6 +39,7 @@ const PostCard = ({ post: {
 
         try {
             await axios.post('/votes', { identifier, slug, value });
+            subMutate();
         } catch (error) {
             console.log(error);
         }        

--- a/client/src/components/PostCard.tsx
+++ b/client/src/components/PostCard.tsx
@@ -1,5 +1,9 @@
 import React from 'react'
 import { Post } from '../types'
+import { FaArrowDown, FaArrowUp } from 'react-icons/fa6'
+import Link from 'next/link'
+import Image from 'next/image'
+import dayjs from 'dayjs'
 
 interface PostCardProps {
     post: Post
@@ -9,7 +13,79 @@ const PostCard = ({ post: {
     identifier, slug, title, body, subName, createdAt, voteScore, userVote, commentCount, url, username, sub
 } }: PostCardProps) => {
   return (
-    <div>PostCard</div>
+    <div
+        className='flex mb-4 bg-white rounded'
+        id={identifier}
+    >
+        {/* Vote */}
+        <div className="flex-shrink-0 w-10 py-2 text-center rounded-l">
+            {/* 좋아요 */}
+            <div
+                className="flex justify-center w-6 mx-auto text-gray-400 rounded cursor-pointer hover:bg-gray-300 hover:text-red-500"
+                // onClick={() => vote(1)}
+            >
+                {userVote === 1 ?
+                    <FaArrowUp className="text-red-500" />
+                    : <FaArrowUp />
+                }
+            </div>
+            <p className="text-xs font-bold">{voteScore}</p>
+            {/* 싫어요 */}
+            <div
+                className="flex justify-center w-6 mx-auto text-gray-400 rounded cursor-pointer hover:bg-gray-300 hover:text-blue-500"
+                // onClick={() => vote(-1)}
+            >
+                {userVote === -1 ?
+                    <FaArrowDown className="text-blue-500" />
+                    : <FaArrowDown />
+                }
+            </div>
+        </div>
+        {/* 포스트 데이터 부분 */}
+        <div className="w-full p-2">
+            {/* <div className='flex items-center'>
+                <Link href={`/r/${subName}`}>
+                    <Image
+                        src={sub!.imageUrl}
+                        alt="sub"
+                        className='rounded-full cursor-pointer'
+                        width={12}
+                        height={12}
+                    />
+                </Link>
+                <Link href={`/r/${subName}`}>
+                    <a className="ml-2 text-xs font-bold cursor-pointer hover:underline">
+                        /r/{subName}
+                    </a>
+                </Link>
+                <span className="mx-1 text-xs text-gray-400">•</span>
+            </div> */}
+
+            <p className="text-xs text-gray-400">
+                Posted by
+                <Link href={`/u/${username}`}>
+                    <span className="mx-1 hover:underline">/u/{username}</span>
+                </Link>
+                <Link href={url}>
+                    <span className='mx-1 hover:underline'>
+                        {dayjs(createdAt).format('YYYY-MM-DD HH:mm')}
+                    </span>
+                </Link>
+            </p>
+            
+            <Link href={url}>
+                <span className="my-1 text-lg font-medium">{title}</span>
+            </Link>
+            {body && <p className="my-1 text-sm">{body}</p>}
+            <div className="flex">
+                <Link href={url}>
+                    <i className="mr-1 fas fa-comment-alt fa-xs"></i>
+                    <span>{commentCount}</span>
+                </Link>
+
+            </div>
+        </div>
+    </div>
   )
 }
 

--- a/client/src/components/PostCard.tsx
+++ b/client/src/components/PostCard.tsx
@@ -32,6 +32,7 @@ const PostCard = ({
  }: PostCardProps) => {
     const { authenticated } = useAuthState()
     const router = useRouter()
+    const isInSubPage = router.pathname === '/r/[sub]'
     const vote = async (value: number) => {
         if (!authenticated) router.push('/login');
         
@@ -75,23 +76,25 @@ const PostCard = ({
             </div>
             {/* 포스트 데이터 부분 */}
             <div className="w-full p-2">
-                {/* <div className='flex items-center'>
-                    <Link href={`/r/${subName}`}>
-                        <Image
-                            src={sub!.imageUrl}
-                            alt="sub"
-                            className='rounded-full cursor-pointer'
-                            width={12}
-                            height={12}
-                        />
-                    </Link>
-                    <Link href={`/r/${subName}`}>
-                        <a className="ml-2 text-xs font-bold cursor-pointer hover:underline">
-                            /r/{subName}
-                        </a>
-                    </Link>
-                    <span className="mx-1 text-xs text-gray-400">•</span>
-                </div> */}
+                {!isInSubPage && (
+                    <div className='flex items-center'>
+                        <Link href={`/r/${subName}`}>
+                            <Image
+                                src={sub!.imageUrl}
+                                alt="sub"
+                                className='rounded-full cursor-pointer'
+                                width={12}
+                                height={12}
+                            />
+                        </Link>
+                        <Link href={`/r/${subName}`}>
+                            <a className="ml-2 text-xs font-bold cursor-pointer hover:underline">
+                                /r/{subName}
+                            </a>
+                        </Link>
+                        <span className="mx-1 text-xs text-gray-400">•</span>
+                    </div>
+                )}
 
                 <p className="text-xs text-gray-400">
                     Posted by

--- a/client/src/pages/r/[sub].tsx
+++ b/client/src/pages/r/[sub].tsx
@@ -15,7 +15,7 @@ const SubPage = () => {
     const fileInputRef = useRef<HTMLInputElement>(null);
     const router = useRouter();
     const subName = router.query.sub;
-    const { data: sub, error } = useSWR(subName ? `/subs/${subName}` : null);
+    const { data: sub, error, mutate } = useSWR(subName ? `/subs/${subName}` : null);
     console.log('sub', sub);
 
     useEffect(() => {
@@ -56,7 +56,7 @@ const SubPage = () => {
         renderPosts = <p className='text-lg text-center'>아직 작성된 포스트가 없습니다.</p>;
     } else {
         renderPosts = sub.posts.map((post: Post) => (
-            <PostCard key={post.identifier} post={post} />
+            <PostCard key={post.identifier} post={post} subMutate={mutate} />
         ));
     }
 

--- a/client/src/pages/r/[sub].tsx
+++ b/client/src/pages/r/[sub].tsx
@@ -1,5 +1,7 @@
+import PostCard from '@/src/components/PostCard';
 import Sidebar from '@/src/components/Sidebar';
 import { useAuthState } from '@/src/context/auth';
+import { Post } from '@/src/types';
 import axios from 'axios'
 import Image from 'next/image';
 import { useRouter } from 'next/router';
@@ -45,6 +47,17 @@ const SubPage = () => {
            fileInput.name = type;
            fileInput.click(); 
         }
+    }
+
+    let renderPosts;
+    if(!sub) {
+        renderPosts = <p className="text-lg text-center">로딩중...</p>;
+    } else if (sub.posts.length === 0) {
+        renderPosts = <p className='text-lg text-center'>아직 작성된 포스트가 없습니다.</p>;
+    } else {
+        renderPosts = sub.posts.map((post: Post) => {
+            <PostCard key={post.identifier} post={post} />
+        });
     }
 
     return (
@@ -101,7 +114,7 @@ const SubPage = () => {
                     </div>
                     {/* Posts & Sidebar */}
                     <div className='flex max-w-5xl px-4 pt-5 mx-auto'>
-                        <div className='w-full md:mr-3 md:w-8/12'></div>
+                        <div className='w-full md:mr-3 md:w-8/12'>{renderPosts}</div>
                         <Sidebar sub={sub} />
                     </div>
                 </>

--- a/client/src/pages/r/[sub].tsx
+++ b/client/src/pages/r/[sub].tsx
@@ -55,9 +55,9 @@ const SubPage = () => {
     } else if (sub.posts.length === 0) {
         renderPosts = <p className='text-lg text-center'>아직 작성된 포스트가 없습니다.</p>;
     } else {
-        renderPosts = sub.posts.map((post: Post) => {
+        renderPosts = sub.posts.map((post: Post) => (
             <PostCard key={post.identifier} post={post} />
-        });
+        ));
     }
 
     return (

--- a/server/src/entities/Post.ts
+++ b/server/src/entities/Post.ts
@@ -46,7 +46,7 @@ export default class Post extends BaseEntity {
     votes: Vote[];
 
     @Expose() get url(): string {
-        return `r/${this.subName}/${this.identifier}/${this.slug}`
+        return `/r/${this.subName}/${this.identifier}/${this.slug}`
     }
 
     @Expose() get commentCount(): number {


### PR DESCRIPTION
## Overview
- 커뮤니티 페이지에 나열될 포스트들 만들어주기
   - post card components, UI, votes func

## Change Log
1. 커뮤니티 페이지에 포스트 나열 UI `client/src/pages/r/[sub].tsx` renderPosts
2. PostCard 컴포넌트 생성 : `client/src/components/PostCard.tsx`
   - 필요한 정보 Props로 가져오기
3. Post Card UI 작성 : `client/src/components/PostCard.tsx`
4. Vote 함수 생성 : `client/src/components/PostCard.tsx`
5. real-time 투표 위한 mutate 적용
6. pathname에 따른 분기 처리 : `client/src/components/PostCard.tsx` isInSubPage
   - 커뮤니티 페이지 뿐만 아니라 메인 페이지에서도 post card 보여줌 
   - 메인  페이지에서는 포스트 데이터 부분이 보이고, 커뮤니티 페이지에서는 안 보이도록 구현
   - pathname이 `/r/[sub]`로 오는지 조건문 걸어줌
   
## Result
<img src="https://github.com/user-attachments/assets/76b1d742-3225-4287-b51b-81b827758634" width="450"> 

- ~~문제 상황~~ (→ #40 에서 해결)
   - ~~선택 해제 안 먹힘~~
   - ~~투표 값에 따른 색 표시가 안 됨~~

## Issue Tags
- Closed: #36 