### PR TITLE
fix: post card's votes problem

### DIFF
--- a/server/src/routes/subs.ts
+++ b/server/src/routes/subs.ts
@@ -25,7 +25,10 @@ const getSub = async (req: Request, res: Response) => {
         });
 
         sub.posts = posts;
-        console.log("posts", posts)
+        
+        if (res.locals.user) {
+            sub.posts.forEach((p) => p.setUserVote(res.locals.user));
+        }
 
         return res.json(sub);
     } catch (error) {


### PR DESCRIPTION
## Trouble Shooting
- 상황
   - 커뮤니티 상세 페이지를 들어갔을 때 투표 수는 잘 나오고, 색만 안 들어감
   - 눌러져 있는 값의 반대 값을 누르면 바로 반영이 되지만, 같은 값을 누르면 선택 해제가 되지 않음
- 분석
   - 커뮤니티의 포스트들을 나열하는 getSub 핸들러의 투표 관련 부분에 문제가 있을 것으로 추측
   - 확인해보니 포스트의 현 정보만 넣어주고, 투표를 반영해주는 부분이 구현되지 않음
   - `근데 어떻게 반대 값을 누를 땐 반영이 된걸까?`
- 해결
   - 포스트들을 하나씩 돌면서 UserVote 함수를 호출하는 코드 작성

## Result
<img src="https://github.com/user-attachments/assets/00fa1918-fda9-40e9-9cb6-b5e2633520fe" width="500"> 

## Issue Tags
- Closed: #39 
- See also: #37