### PR TITLE
feat: post cards w/ infinite scroll in main page

### DIFF
--- a/client/src/components/PostCard.tsx
+++ b/client/src/components/PostCard.tsx
@@ -10,7 +10,7 @@ import { useRouter } from 'next/router'
 
 interface PostCardProps {
     post: Post
-    subMutate: () => void
+    subMutate?: () => void
 }
 
 const PostCard = ({ 
@@ -40,7 +40,7 @@ const PostCard = ({
 
         try {
             await axios.post('/votes', { identifier, slug, value });
-            subMutate();
+            if (subMutate) subMutate();
         } catch (error) {
             console.log(error);
         }        
@@ -88,9 +88,9 @@ const PostCard = ({
                             />
                         </Link>
                         <Link href={`/r/${subName}`}>
-                            <a className="ml-2 text-xs font-bold cursor-pointer hover:underline">
+                            <span className="ml-2 text-xs font-bold cursor-pointer hover:underline">
                                 /r/{subName}
-                            </a>
+                            </span>
                         </Link>
                         <span className="mx-1 text-xs text-gray-400">•</span>
                     </div>

--- a/client/src/components/PostCard.tsx
+++ b/client/src/components/PostCard.tsx
@@ -11,6 +11,7 @@ import { useRouter } from 'next/router'
 interface PostCardProps {
     post: Post
     subMutate?: () => void
+    mutate?: () => void
 }
 
 const PostCard = ({ 
@@ -28,6 +29,7 @@ const PostCard = ({
         username, 
         sub
     },
+    mutate,
     subMutate
  }: PostCardProps) => {
     const { authenticated } = useAuthState()
@@ -40,6 +42,7 @@ const PostCard = ({
 
         try {
             await axios.post('/votes', { identifier, slug, value });
+            if (mutate) mutate();
             if (subMutate) subMutate();
         } catch (error) {
             console.log(error);

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -76,6 +76,7 @@ export default function Home() {
           <PostCard
             key={post.identifier}
             post={post}
+            mutate={mutate}
           />
         ))}
         {isValidating && posts.length > 0 && (

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -5,6 +5,7 @@ import axios from "axios";
 import Image from "next/image";
 import { useAuthState } from "../context/auth";
 import useSWRInfinite from "swr/infinite";
+import PostCard from "../components/PostCard";
 
 export default function Home() {
   const { authenticated } = useAuthState();
@@ -25,13 +26,22 @@ export default function Home() {
     isValidating, 
     mutate
   } = useSWRInfinite<Post[]>(getKey);
-
+  const isInitialLoading = !data && !error;
+  const posts: Post[] = data ? ([] as Post[]).concat(...data) : [];
   const { data: topSubs } = useSWR<Sub[]>(address, fetcher);
   
   return (
     <div className='flex max-w-5xl px-4 pt-5 mx-auto'>
       {/* 포스트 리스트 */}
-      <div className='w-full md:mr-3 md:w-8/12'>  </div>
+      <div className='w-full md:mr-3 md:w-8/12'>  
+        {isInitialLoading && <p className="text-lg text-center">Loading...</p>}
+        {posts?.map((post) => (
+          <PostCard
+            key={post.identifier}
+            post={post}
+          />
+        ))}
+      </div>
 
       {/* 사이드바 */}
       <div className='hidden w-4/12 ml-3 md:block'>

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -1,17 +1,33 @@
 import Link from "next/link"
 import useSWR from "swr";
-import { Sub } from "../types";
+import { Post, Sub } from "../types";
 import axios from "axios";
 import Image from "next/image";
 import { useAuthState } from "../context/auth";
+import useSWRInfinite from "swr/infinite";
 
 export default function Home() {
   const { authenticated } = useAuthState();
   const fetcher = async (url: string) =>
     await axios.get(url).then(res => res.data);
   const address = "http://localhost:4000/api/subs/sub/topSubs";
+
+  const getKey = (pageIndex: number, previousPageData: Post[]) => {
+    if (previousPageData && !previousPageData.length) return null
+    return `/posts?page=${pageIndex}`;
+  }
+
+  const {
+    data, 
+    error, 
+    size: page, 
+    setSize: setPage, 
+    isValidating, 
+    mutate
+  } = useSWRInfinite<Post[]>(getKey);
+
   const { data: topSubs } = useSWR<Sub[]>(address, fetcher);
-  console.log('topSubs', topSubs)
+  
   return (
     <div className='flex max-w-5xl px-4 pt-5 mx-auto'>
       {/* 포스트 리스트 */}

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -78,6 +78,9 @@ export default function Home() {
             post={post}
           />
         ))}
+        {isValidating && posts.length > 0 && (
+          <p className="text-lg text-center">Loading More..</p>
+        )}
       </div>
 
       {/* 사이드바 */}

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -6,6 +6,7 @@ import Image from "next/image";
 import { useAuthState } from "../context/auth";
 import useSWRInfinite from "swr/infinite";
 import PostCard from "../components/PostCard";
+import { useEffect, useState } from "react";
 
 export default function Home() {
   const { authenticated } = useAuthState();
@@ -30,6 +31,42 @@ export default function Home() {
   const posts: Post[] = data ? ([] as Post[]).concat(...data) : [];
   const { data: topSubs } = useSWR<Sub[]>(address, fetcher);
   
+  const [observedPost, setObservedPost] = useState("");
+
+  // Infinite Scroll 기능 구현
+  useEffect(() => {
+    // post가 없다면 return
+    if (!posts || posts.length === 0) return;
+    // posts 배열 안 마지막 post의 id 가져오기
+    const id = posts[posts.length-1].identifier;
+    // posts 배열에 post가 추가돼서 마지막 post가 바뀌었다면
+    // 바뀐 post 중 마지막 post를 observedPost로 지정
+    if (id !== observedPost) {
+      setObservedPost(id);
+      observeElement(document.getElementById(id));
+    }
+  }, [posts]);
+
+  const observeElement = (element: HTMLElement | null) => {
+    if (!element) return;
+    // 브라우저 Viewport와 설정한 Element의 교차점을 관찰
+    const observer = new IntersectionObserver(
+      // entries: IntersectionObserverEntry Instance의 배열
+      (entries) => {
+        // isIntersecting: 관찰 대상의 교차 상태 (Boolean)
+        if (entries[0].isIntersecting === true) {
+          console.log("Reached bottom of post");
+          setPage(page + 1);
+          observer.unobserve(element);
+        }
+      },
+      // 옵저버가 실행되기 위해 타겟의 가시성이 얼마나 필요한지 백분율로 표시
+      { threshold: 1 }
+    );
+    // 대상 요소의 관찰을 시작
+    observer.observe(element);
+  }
+
   return (
     <div className='flex max-w-5xl px-4 pt-5 mx-auto'>
       {/* 포스트 리스트 */}

--- a/server/src/routes/posts.ts
+++ b/server/src/routes/posts.ts
@@ -5,6 +5,29 @@ import Sub from "../entities/Sub";
 import Post from "../entities/Post";
 import Comment from "../entities/Comment";
 
+const getPosts = async (req: Request, res: Response) => {
+    const currentPage: number = (req.query.page || 0) as number;
+    const perPage: number = (req.query.count || 8) as number;
+
+    try {
+        const posts = await Post.find({
+            order: { createdAt: "DESC" },
+            relations: ["sub", "votes", "comments"],
+            skip: currentPage * perPage,
+            take: perPage
+        });
+
+        if (res.locals.user) {
+            posts.forEach((p) => p.setUserVote(res.locals.user));
+        }
+
+        return res.json(posts);
+    } catch (error) {
+        console.log(error);
+        return res.status(500).json({ error: "문제가 발생했습니다." });
+    }
+}
+
 const getPost = async (req: Request, res: Response) => {
     const { identifier, slug } = req.params;
     try {
@@ -95,6 +118,7 @@ const createPostComment = async (req: Request, res: Response) => {
 const router = Router();
 router.get("/:identifier/:slug", userMiddleware, getPost)
 router.post("/", userMiddleware, authMiddleware, createPost);
+router.get("/", userMiddleware, getPosts)
 router.get("/:identifier/:slug/comments", userMiddleware, getPostComment);
 router.post("/:identifier/:slug/comments", userMiddleware, createPostComment);
 export default router;


### PR DESCRIPTION
## Overview
- 각 커뮤니티별로 생성된 포스트들을 메인 페이지에 나열하기
- 모든 포스트를 한번에 가져오지 않고, 스크롤을 내릴 때마다 포스트를 추가로 가져오도록 구현
1. SWR은 페이지 매김 및 무한 로딩과 같은 일반적인 UI 패턴을 지원하기 위해 전용 API로 useSWRInfinite 제공
2. Intersection observer는 req.query.count로 지정된 마지막 element를 observe 하고 있다가, viewport에 intersect 될 때 새로운 데이터를 불러옴
   - 비동기적으로 실행되기 때문에, scroll 같은 이벤트 기반의 요소 관찰에서 발생하는 렌더링 성능이나 이벤트 연속 호출 같은 문제 없이 사용할 수 있음

## Change Log
1. [useSWRInfinite](https://swr.vercel.app/docs/pagination#useswrinfinite)을 이용하여 무한 스크롤 구현
   1. 각 페이지의 SWR 키를 얻기 위한 함수 작성 : `client/src/pages/index.tsx` getKey
   2. getKey에서 요청을 보내는 `/posts?page=` 경로를 라우터에 등록 및 getPosts 핸들러 생성 : `server/src/routes/posts.ts`
   3. 메인 페이지에 포스트 나열하기 : `client/src/pages/index.tsx`
      - 처음 포스트 가져올 때 (`!data && !error`)  "Loading" 출력 
      - 다음 페이지 포스트 가져올 때 (`isValidating`) "Loading More..." 출력
2. [Intersection observer](https://velog.io/@katanazero86/Intersection-Observer-API)을 이용하여 스크롤을 내릴 때 포스트 추가로 가져오기
   1. Infinite Scroll 기능 구현 : `client/src/pages/index.tsx`
   2. 포스트 투표 시 바로 반영 되도록 useSWR의 mutate를 post card에 props로 넣어주고, interface에 넣어줌

## Result
<img src="https://github.com/user-attachments/assets/5437950c-fd60-4d83-9cf5-dbc5da9062ac" width="550"> 

## Issue Tags
- Closed: #38