### PR TITLE
feat: delete community, post and comment

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,6 +8,7 @@
       "name": "client",
       "version": "0.1.0",
       "dependencies": {
+        "axios": "^1.7.5",
         "classnames": "^2.5.1",
         "dayjs": "^1.11.11",
         "env-cmd": "^10.1.0",
@@ -2320,6 +2321,11 @@
       "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
       "dev": true
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.19",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.19.tgz",
@@ -2379,6 +2385,16 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.5.tgz",
+      "integrity": "sha512-fZu86yCo+svH3uqJ/yTdQ0QHpQu5oL+/QE+QPSv6BZSkDAoky9vytxp7u5qk83OJFS3kEBcesWni9WTZAv3tSw==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -2626,6 +2642,17 @@
       "dependencies": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/commander": {
@@ -2880,6 +2907,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/dequal": {
@@ -3687,6 +3722,25 @@
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
       "dev": true
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -3710,6 +3764,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fraction.js": {
@@ -4708,6 +4775,25 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {
@@ -6021,6 +6107,11 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/client/package.json
+++ b/client/package.json
@@ -11,6 +11,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "axios": "^1.7.5",
     "classnames": "^2.5.1",
     "dayjs": "^1.11.11",
     "env-cmd": "^10.1.0",

--- a/client/src/components/PostCard.tsx
+++ b/client/src/components/PostCard.tsx
@@ -1,6 +1,6 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { Post } from '../types'
-import { FaArrowDown, FaArrowUp } from 'react-icons/fa6'
+import { FaArrowDown, FaArrowUp, FaEllipsisV } from 'react-icons/fa'
 import Link from 'next/link'
 import Image from 'next/image'
 import dayjs from 'dayjs'
@@ -12,6 +12,7 @@ interface PostCardProps {
     post: Post
     subMutate?: () => void
     mutate?: () => void
+    onDelete: (identifier: string, slug: string) => void
 }
 
 const PostCard = ({ 
@@ -30,11 +31,14 @@ const PostCard = ({
         sub
     },
     mutate,
-    subMutate
+    subMutate,
+    onDelete
  }: PostCardProps) => {
     const { authenticated } = useAuthState()
     const router = useRouter()
     const isInSubPage = router.pathname === '/r/[sub]'
+    const [showDeleteOption, setShowDeleteOption] = useState(false)
+
     const vote = async (value: number) => {
         if (!authenticated) router.push('/login');
         
@@ -79,38 +83,64 @@ const PostCard = ({
             </div>
             {/* 포스트 데이터 부분 */}
             <div className="w-full p-2">
-                <div className="flex items-center">
-                    {!isInSubPage && (
-                        <div className='flex items-center'>
-                            <Link href={`/r/${subName}`}>
-                                <Image
-                                    src={sub!.imageUrl}
-                                    alt="sub"
-                                    className='rounded-full cursor-pointer'
-                                    width={12}
-                                    height={12}
-                                />
+                <div className="flex items-center justify-between">
+                    <div className="flex items-center">
+                        {!isInSubPage && (
+                            <div className='flex items-center'>
+                                <Link href={`/r/${subName}`}>
+                                    <Image
+                                        src={sub!.imageUrl}
+                                        alt="sub"
+                                        className='rounded-full cursor-pointer'
+                                        width={12}
+                                        height={12}
+                                    />
+                                </Link>
+                                <Link href={`/r/${subName}`}>
+                                    <span className="ml-2 text-xs font-bold cursor-pointer hover:underline">
+                                        /r/{subName}
+                                    </span>
+                                </Link>
+                                <span className="mx-1 text-xs text-gray-400">•</span>
+                            </div>
+                        )}
+
+                        <p className="text-xs text-gray-400">
+                            Posted by
+                            <Link href={`/u/${username}`}>
+                                <span className="mx-1 hover:underline">/u/{username}</span>
                             </Link>
-                            <Link href={`/r/${subName}`}>
-                                <span className="ml-2 text-xs font-bold cursor-pointer hover:underline">
-                                    /r/{subName}
+                            <Link href={url}>
+                                <span className='mx-1 hover:underline'>
+                                    {dayjs(createdAt).format('YYYY-MM-DD HH:mm')}
                                 </span>
                             </Link>
-                            <span className="mx-1 text-xs text-gray-400">•</span>
+                        </p>
+                    </div>
+
+                    {authenticated && (
+                        <div className="relative">
+                            <button
+                                className="px-1 py-1 text-xs text-gray-400 rounded"
+                                onClick={() => setShowDeleteOption(!showDeleteOption)}
+                            >
+                                <FaEllipsisV />
+                            </button>
+                            {showDeleteOption && (
+                                <div className="absolute right-0 top-full mb-1 w-32 py-2 bg-white rounded-lg shadow-xl">
+                                    <button
+                                        className="block w-full px-4 py-2 text-xs text-left text-gray-700 hover:bg-gray-100"
+                                        onClick={() => {
+                                            onDelete(identifier, slug);
+                                            setShowDeleteOption(false);
+                                        }}
+                                    >
+                                        삭제
+                                    </button>
+                                </div>
+                            )}
                         </div>
                     )}
-
-                    <p className="text-xs text-gray-400">
-                        Posted by
-                        <Link href={`/u/${username}`}>
-                            <span className="mx-1 hover:underline">/u/{username}</span>
-                        </Link>
-                        <Link href={url}>
-                            <span className='mx-1 hover:underline'>
-                                {dayjs(createdAt).format('YYYY-MM-DD HH:mm')}
-                            </span>
-                        </Link>
-                    </p>
                 </div>
 
                 <Link href={url}>
@@ -122,7 +152,6 @@ const PostCard = ({
                         <i className="mr-1 fas fa-comment-alt fa-xs"></i>
                         <span>{commentCount}</span>
                     </Link>
-
                 </div>
             </div>
         </div>

--- a/client/src/components/Sidebar.tsx
+++ b/client/src/components/Sidebar.tsx
@@ -3,12 +3,27 @@ import { useAuthState } from '../context/auth'
 import { Sub } from '../types'
 import Link from 'next/link'
 import dayjs from 'dayjs'
+import axios from 'axios'
+import { useRouter } from 'next/router'
 type Props = {
     sub: Sub
 }
 
 const Sidebar = ({ sub }: Props) => {
     const { authenticated } = useAuthState();
+    const router = useRouter();
+
+    const deleteSub = async () => {
+        if (confirm("정말로 이 커뮤니티를 삭제하시겠습니까?")) {
+            try {
+                await axios.delete(`/subs/${sub.name}`);
+                router.push("/");
+            } catch (error) {
+                console.log(error);
+            }
+        }
+    };
+
     return (
     <div className='hidden w-4/12 ml-3 md:block'>
             <div className='bg-white border rounded'>
@@ -29,11 +44,19 @@ const Sidebar = ({ sub }: Props) => {
 
                     {authenticated && (
                         <div className='mx-0 my-2'>
-                            <Link href={`/r/${sub.name}/create`}>
-                                <span className="w-full p-2 text-sm text-white bg-gray-400 rounded">
-                                    포스트 생성
-                                </span>
-                            </Link>
+                            <div className="flex justify-between gap-2">
+                                <Link href={`/r/${sub.name}/create`} className="flex-1">
+                                    <span className="block p-2 text-sm text-white bg-gray-400 rounded text-center">
+                                        포스트 생성
+                                    </span>
+                                </Link>
+                                <button
+                                    className="flex-1 p-2 text-sm text-white bg-red-500 rounded"
+                                    onClick={deleteSub}
+                                >
+                                    커뮤니티 삭제
+                                </button>
+                            </div>
                         </div>
                     )}
                 </div>

--- a/client/src/pages/_app.tsx
+++ b/client/src/pages/_app.tsx
@@ -1,5 +1,4 @@
 import '../styles/globals.css'
-import Axios from "axios";
 import type { AppProps } from "next/app";
 import { AuthProvider } from '../context/auth';
 import { useRouter } from 'next/router';
@@ -9,8 +8,8 @@ import axios from 'axios';
 import Head from 'next/head';
 
 export default function App({ Component, pageProps }: AppProps) {
-  Axios.defaults.baseURL = process.env.NEXT_PUBLIC_SERVER_BASE_URL + "/api";
-  Axios.defaults.withCredentials = true;
+  axios.defaults.baseURL = process.env.NEXT_PUBLIC_SERVER_BASE_URL + "/api";
+  axios.defaults.withCredentials = true;
 
   const { pathname } = useRouter();
   const authRoutes = ["/register", "/login"];

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -19,6 +19,15 @@ export default function Home() {
     return `/posts?page=${pageIndex}`;
   }
 
+  const handlePostDelete = async (identifier: string, slug: string) => {
+    try {
+      await axios.delete(`/posts/${identifier}/${slug}`);
+      mutate();
+    } catch (error) {
+      console.log(error);
+    }
+  }
+
   const {
     data, 
     error, 
@@ -77,6 +86,7 @@ export default function Home() {
             key={post.identifier}
             post={post}
             mutate={mutate}
+            onDelete={handlePostDelete}
           />
         ))}
         {isValidating && posts.length > 0 && (

--- a/client/src/pages/r/[sub].tsx
+++ b/client/src/pages/r/[sub].tsx
@@ -16,7 +16,14 @@ const SubPage = () => {
     const router = useRouter();
     const subName = router.query.sub;
     const { data: sub, error, mutate } = useSWR(subName ? `/subs/${subName}` : null);
-    console.log('sub', sub);
+    const handlePostDelete = async (identifier: string, slug: string) => {
+        try {
+          await axios.delete(`/posts/${identifier}/${slug}`);
+          mutate();
+        } catch (error) {
+          console.log(error);
+        }
+    }
 
     useEffect(() => {
         if(!sub) return;
@@ -56,7 +63,7 @@ const SubPage = () => {
         renderPosts = <p className='text-lg text-center'>아직 작성된 포스트가 없습니다.</p>;
     } else {
         renderPosts = sub.posts.map((post: Post) => (
-            <PostCard key={post.identifier} post={post} subMutate={mutate} />
+            <PostCard key={post.identifier} post={post} subMutate={mutate} onDelete={handlePostDelete} />
         ));
     }
 

--- a/client/src/pages/r/[sub]/[identifier]/[slug].tsx
+++ b/client/src/pages/r/[sub]/[identifier]/[slug].tsx
@@ -109,17 +109,17 @@ const PostPage = () => {
                                             <FaArrowDown className="text-blue-500"/> : <FaArrowDown/>}
                                     </div>
                                 </div>
-                                <div className="py-2 pr-2">
+                                <div className="py-2 pr-2 w-full">
                                     <div className="flex items-center justify-between">
                                         <p className="text-xs text-gray-400">
                                             Posted by 
                                             <Link href={`/u/${post.username}`}>
-                                                <span className="mx-1 hover:underline">
+                                                <span className="hover:underline">
                                                     /u/{post.username}
                                                 </span>
                                             </Link>
                                             <Link href={post.url}>
-                                                <span className="mx-1 hover:underline">
+                                                <span className="hover:underline">
                                                     {dayjs(post.createdAt).format("YYYY-MM-DD HH:mm")}
                                                 </span>
                                             </Link>

--- a/client/src/pages/r/[sub]/[identifier]/[slug].tsx
+++ b/client/src/pages/r/[sub]/[identifier]/[slug].tsx
@@ -7,7 +7,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { FormEvent, useState } from 'react';
 import useSWR from 'swr';
-import { FaArrowDown, FaArrowUp } from "react-icons/fa6";
+import { FaArrowDown, FaArrowUp, FaEllipsisV } from "react-icons/fa";
 
 const PostPage = () => {
     const router = useRouter();
@@ -20,7 +20,7 @@ const PostPage = () => {
     const { data: comments, mutate: commentMutate } = useSWR<Comment[]>(
         identifier && slug ? `/posts/${identifier}/${slug}/comments` : null
     )
-    console.log("comments", comments)
+    const [showDeleteOption, setShowDeleteOption] = useState(false)
     const handleSubmit = async (e: FormEvent) => {
         e.preventDefault();
         if (newComment.trim() === "") return;
@@ -61,6 +61,15 @@ const PostPage = () => {
         }
     }
 
+    const onDelete = async (identifier: string, slug: string) => {
+        try {
+            await axios.delete(`/posts/${identifier}/${slug}`);
+            router.push('/');
+        } catch (error) {
+            console.log(error);
+        }
+    }
+
     return (
         <div className="flex max-w-5xl px-4 pt-5 mx-auto">
             {/* Post */}
@@ -90,8 +99,8 @@ const PostPage = () => {
                                     </div>
                                 </div>
                                 <div className="py-2 pr-2">
-                                    <div className="flex items-center">
-                                        <p className="text-xs test-gray-400">
+                                    <div className="flex items-center justify-between">
+                                        <p className="text-xs text-gray-400">
                                             Posted by 
                                             <Link href={`/u/${post.username}`}>
                                                 <span className="mx-1 hover:underline">
@@ -104,7 +113,31 @@ const PostPage = () => {
                                                 </span>
                                             </Link>
                                         </p>
+                                        {authenticated && (
+                                            <div className="relative">
+                                                <button
+                                                    className="px-1 py-1 text-xs text-gray-400 rounded"
+                                                    onClick={() => setShowDeleteOption(!showDeleteOption)}
+                                                >
+                                                    <FaEllipsisV />
+                                                </button>
+                                                {showDeleteOption && (
+                                                    <div className="absolute right-0 top-full mb-1 w-32 py-2 bg-white rounded-lg shadow-xl">
+                                                        <button
+                                                            className="block w-full px-4 py-2 text-xs text-left text-gray-700 hover:bg-gray-100"
+                                                            onClick={() => {
+                                                                onDelete(post.identifier, post.slug);
+                                                                setShowDeleteOption(false);
+                                                            }}
+                                                        >
+                                                            삭제
+                                                        </button>
+                                                    </div>
+                                                )}
+                                            </div>
+                                        )}
                                     </div>
+
                                     <h1 className="my-1 text-xl font-medium">{post.title}</h1>
                                     <p className="my-3 text-sm">{post.body}</p>
                                     <div className="flex">

--- a/client/src/pages/r/[sub]/[identifier]/[slug].tsx
+++ b/client/src/pages/r/[sub]/[identifier]/[slug].tsx
@@ -21,6 +21,8 @@ const PostPage = () => {
         identifier && slug ? `/posts/${identifier}/${slug}/comments` : null
     )
     const [showDeleteOption, setShowDeleteOption] = useState(false)
+    const [showDeleteCommentOption, setShowDeleteCommentOption] = useState<string | null>(null);
+
     const handleSubmit = async (e: FormEvent) => {
         e.preventDefault();
         if (newComment.trim() === "") return;
@@ -30,6 +32,15 @@ const PostPage = () => {
             });
             commentMutate();
             setNewComment("");
+        } catch (error) {
+            console.log(error);
+        }
+    }
+
+    const onDeleteComment = async (identifier: string) => {
+        try {
+            await axios.delete(`/posts/${post?.identifier}/${post?.slug}/comments/${identifier}`);
+            commentMutate();
         } catch (error) {
             console.log(error);
         }
@@ -217,21 +228,47 @@ const PostPage = () => {
                                                 <FaArrowDown className="text-blue-500"/> : <FaArrowDown/>}
                                         </div>
                                     </div>
-                                    <div className="py-2 pr-2">
-                                        <p className="mb-1 text-xs leading-none">
-                                            <Link href={`/u/${comment.username}`}>
-                                                <span className="mr-1 font-bold hover:underline">
-                                                    {comment.username}
+                                    <div className="py-2 pr-2 w-full">
+                                        <div className="flex items-center justify-between">
+                                            <p className="mb-1 text-xs leading-none">
+                                                <Link href={`/u/${comment.username}`}>
+                                                    <span className="mr-1 font-bold hover:underline">
+                                                        {comment.username}
+                                                    </span>
+                                                </Link>
+                                                <span className="text-gray-600">
+                                                    {`
+                                                        ${comment.voteScore}
+                                                        posts
+                                                        ${dayjs(comment.createdAt).format("YYYY-MM-DD HH:mm")}
+                                                    `}
                                                 </span>
-                                            </Link>
-                                            <span className="text-gray-600">
-                                                {`
-                                                    ${comment.voteScore}
-                                                    posts
-                                                    ${dayjs(comment.createdAt).format("YYYY-MM-DD HH:mm")}
-                                                `}
-                                            </span>
-                                        </p>
+                                            </p>
+                                            {/* 댓글 삭제 */}
+                                            {authenticated && (user?.username === comment.username) && (
+                                                <div className="relative">
+                                                    <button
+                                                        className="px-1 py-1 text-xs text-gray-400 rounded"
+                                                        onClick={() => setShowDeleteCommentOption(comment.identifier)}
+                                                    >
+                                                        <FaEllipsisV />
+                                                    </button>
+                                                    {showDeleteCommentOption === comment.identifier && (
+                                                        <div className="absolute right-0 top-full mb-1 w-32 py-2 bg-white rounded-lg shadow-xl">
+                                                            <button
+                                                                className="block w-full px-4 py-2 text-xs text-left text-gray-700 hover:bg-gray-100"
+                                                                onClick={() => {
+                                                                    onDeleteComment(comment.identifier);
+                                                                    setShowDeleteCommentOption(null);
+                                                                }}
+                                                            >
+                                                                삭제
+                                                            </button>
+                                                        </div>
+                                                    )}
+                                                </div>
+                                            )}
+                                        </div>                
                                         <p>{comment.body}</p>
                                     </div>
                                 </div>

--- a/client/src/pages/u/[username].tsx
+++ b/client/src/pages/u/[username].tsx
@@ -6,12 +6,22 @@ import Link from 'next/link';
 import { useRouter } from 'next/router'
 import React from 'react'
 import useSWR from 'swr';
-
+import axios from 'axios';
 const UserPage = () => {
     const router = useRouter();
     const username = router.query.username;
 
-    const { data, error } = useSWR<any>(username ? `/users/${username}` : null);
+    const { data, error, mutate } = useSWR<any>(username ? `/users/${username}` : null);
+
+    const handlePostDelete = async (identifier: string, slug: string) => {
+        try {
+            await axios.delete(`/posts/${identifier}/${slug}`);
+            mutate();
+        } catch (error) {
+            console.log(error);
+        }
+    }
+
     if (!data) return null;
     return (
         <div className="flex max-w-5xl px-4 pt-5 mx-auto">
@@ -20,7 +30,7 @@ const UserPage = () => {
                 {data.userData.map((data: any) => {
                     if (data.type === "Post") {
                         const post: Post = data;
-                        return <PostCard key={post.identifier} post={post} />
+                        return <PostCard key={post.identifier} post={post} onDelete={handlePostDelete} />
                     } else {
                         const comment: Comment = data;
                         return (

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,6 +9,9 @@
          "version": "1.0.0",
          "license": "ISC",
          "dependencies": {
+            "bcryptjs": "^2.4.3",
+            "class-transformer": "^0.5.1",
+            "class-validator": "^0.14.1",
             "cookie": "^0.6.0",
             "cookie-parser": "^1.4.6",
             "cors": "^2.8.5",
@@ -24,6 +27,7 @@
             "typeorm": "0.3.20"
          },
          "devDependencies": {
+            "@types/bcryptjs": "^2.4.6",
             "@types/cookie": "^0.6.0",
             "@types/cookie-parser": "^1.4.7",
             "@types/cors": "^2.8.17",
@@ -126,6 +130,12 @@
          "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
          "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
          "devOptional": true
+      },
+      "node_modules/@types/bcryptjs": {
+         "version": "2.4.6",
+         "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.6.tgz",
+         "integrity": "sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==",
+         "dev": true
       },
       "node_modules/@types/body-parser": {
          "version": "1.19.5",
@@ -272,6 +282,11 @@
             "@types/send": "*"
          }
       },
+      "node_modules/@types/validator": {
+         "version": "13.12.1",
+         "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.12.1.tgz",
+         "integrity": "sha512-w0URwf7BQb0rD/EuiG12KP0bailHKHP5YVviJG9zw3ykAokL0TuxU2TUqMB7EwZ59bDHYdeTIvjI5m0S7qHfOA=="
+      },
       "node_modules/accepts": {
          "version": "1.3.8",
          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -410,6 +425,11 @@
          "version": "5.1.2",
          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      },
+      "node_modules/bcryptjs": {
+         "version": "2.4.3",
+         "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+         "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ=="
       },
       "node_modules/binary-extensions": {
          "version": "2.3.0",
@@ -590,6 +610,21 @@
          },
          "optionalDependencies": {
             "fsevents": "~2.3.2"
+         }
+      },
+      "node_modules/class-transformer": {
+         "version": "0.5.1",
+         "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
+         "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw=="
+      },
+      "node_modules/class-validator": {
+         "version": "0.14.1",
+         "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.1.tgz",
+         "integrity": "sha512-2VEG9JICxIqTpoK1eMzZqaV+u/EiwEJkMGzTrZf6sU/fwsnOITVgYJ8yojSy6CaXtO9V0Cc6ZQZ8h8m4UBuLwQ==",
+         "dependencies": {
+            "@types/validator": "^13.11.8",
+            "libphonenumber-js": "^1.10.53",
+            "validator": "^13.9.0"
          }
       },
       "node_modules/cli-highlight": {
@@ -1501,6 +1536,11 @@
             "jwa": "^1.4.1",
             "safe-buffer": "^5.0.1"
          }
+      },
+      "node_modules/libphonenumber-js": {
+         "version": "1.11.7",
+         "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.11.7.tgz",
+         "integrity": "sha512-x2xON4/Qg2bRIS11KIN9yCNYUjhtiEjNyptjX0mX+pyKHecxuJVLIpfX1lq9ZD6CrC/rB+y4GBi18c6CEcUR+A=="
       },
       "node_modules/lodash.includes": {
          "version": "4.3.0",
@@ -2695,6 +2735,14 @@
          "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
          "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
          "devOptional": true
+      },
+      "node_modules/validator": {
+         "version": "13.12.0",
+         "resolved": "https://registry.npmjs.org/validator/-/validator-13.12.0.tgz",
+         "integrity": "sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==",
+         "engines": {
+            "node": ">= 0.10"
+         }
       },
       "node_modules/vary": {
          "version": "1.1.2",

--- a/server/package.json
+++ b/server/package.json
@@ -13,6 +13,9 @@
    "author": "",
    "license": "ISC",
    "dependencies": {
+      "bcryptjs": "^2.4.3",
+      "class-transformer": "^0.5.1",
+      "class-validator": "^0.14.1",
       "cookie": "^0.6.0",
       "cookie-parser": "^1.4.6",
       "cors": "^2.8.5",
@@ -28,6 +31,7 @@
       "typeorm": "0.3.20"
    },
    "devDependencies": {
+      "@types/bcryptjs": "^2.4.6",
       "@types/cookie": "^0.6.0",
       "@types/cookie-parser": "^1.4.7",
       "@types/cors": "^2.8.17",

--- a/server/src/entities/Vote.ts
+++ b/server/src/entities/Vote.ts
@@ -25,6 +25,10 @@ export default class Vote extends BaseEntity {
     @Column({nullable: true})
     commentId: number;
 
-    @ManyToOne(() => Comment)
+    @ManyToOne(() => Comment, (comment) => comment.votes, {
+        // comment를 삭제할 때 연관된 vote도 자동으로 삭제되도록 외래 키 제약 조건을 ON DELETE CASCADE로 설정
+        onDelete: "CASCADE"
+    })
+    @JoinColumn({ name: "commentId" })
     comment: Comment;
 }


### PR DESCRIPTION
## Overview
- 생성된 커뮤니티, 포스트, 댓글을 삭제하는 기능 개발

## Change Log
1. 삭제 버튼 구현
2. 버튼을 누르면 onClick 이벤트가 발생하고, 그에 맞는 handler 함수를 호출
3. 핸들러 함수에서 해당 포스트나 댓글의 ID를 백엔드 서버로 전송
4. 백엔드 서버에 있는 라우트 핸들러에서 해당 포스트나 댓글의 ID를 수신
5. 데이터베이스에 저장된 데이터 삭제

## Result
- 커뮤니티 삭제 기능
   <img src=https://github.com/user-attachments/assets/bce0c11f-2eae-41e2-be13-85d066df7e20 width=300>
- 포스트와 댓글 삭제 기능
   <img src=https://github.com/user-attachments/assets/181948bc-0e6c-4671-8e4d-9fdd93c68b0c width=500> 

## Issue Tags
- Closed: #48 