### PR TITLE
chore: deploy frontend to vercel

### DIFF
--- a/client/vercel.json
+++ b/client/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/:path*",
+      "destination": "http://ec2-52-78-129-10.ap-northeast-2.compute.amazonaws.com/:path*"
+    }
+  ]
+}


### PR DESCRIPTION
## Overview
- AWS 에서 배포했던 프론트 서버를 vercel로 배포
   1. AWS 리소스 절약을 위해 
   2. Analytics, Logs 등의 vercel 자체 기능을 사용해보기 위해

## Change Log
- **프론트** | 백엔드 서버와 통신을 하기 위한 config 파일 작성 : `client/vercel.json`
   - Next.js에서 제공하는 rewrites(프록시)을 통해 API 호출
   - 프론트 서버로 들어오는 API 요청들은 아래와 같은 순서로 동작
      <img src=https://github.com/user-attachments/assets/bb84c09b-63bd-4aad-a2c9-b02e792c73f2 width=500>
      출처 : https://oliveyoung.tech/blog/2024-01-23/msw-frontend/
-  **백엔드** | cors 설정에 사용되는, 백엔드가 요청을 허용할 수 있는 프론트 주소 `process.env.ORIGIN`을 `https://preddit-on.vercel.app` 으로 수정
- vercel은 기본적으로 https 요청을 하는데, http 요청이 필요하기 때문에 다음과 같은 작업 수행
   <img src=https://github.com/user-attachments/assets/e08c5327-576e-4028-b62c-c09182bfff75 width=200>
   사이트 설정
   <img src=https://github.com/user-attachments/assets/a5170a33-1ee5-425e-b544-4a6cf45eabf6 width=450>
   안전하지 않은 콘텐츠 - 허용

## Reference
- https://ash9river.tistory.com/58