### PR TITLE
hotfix: image loading problem (nextConfig)

### DIFF
--- a/client/next.config.mjs
+++ b/client/next.config.mjs
@@ -5,7 +5,8 @@ const nextConfig = {
     domains: [
       "www.gravatar.com", 
       "localhost",
-      "preddit-on.vercel.app"
+      "preddit-on.vercel.app",
+      "ec2-13-124-135-251.ap-northeast-2.compute.amazonaws.com"
     ]
   }
 };


### PR DESCRIPTION
## Problem
- 커뮤니티 프로필 이미지들이 로딩이 안되는 문제
   <img src=https://github.com/user-attachments/assets/ecc383da-eddd-4200-b33b-94be5ed0bfe4 width=800>

## How to Solve
- next.config.mjs 파일의 images-domains에 서버 도메인 포함

## Result
<img src=https://github.com/user-attachments/assets/e825f66f-aa61-4016-bd31-761d2403e577 width=800>