### PR TITLE
hotfix: text in ai-reply is not visible in dark mode

### DIFF
--- a/client/src/pages/r/[sub]/[identifier]/[slug].tsx
+++ b/client/src/pages/r/[sub]/[identifier]/[slug].tsx
@@ -301,7 +301,7 @@ const PostPage = () => {
                                                 </button>
                                             </div>
                                             {aiResponse && (
-                                                <div className="mt-4 p-4 bg-gray-100 rounded-md mr-8">
+                                                <div className="mt-4 p-4 bg-compat rounded-md mr-8">
                                                     <p className="text-sm">{formatAIResponse(aiResponse)}</p>
                                                 </div>
                                             )}
@@ -318,7 +318,7 @@ const PostPage = () => {
                                                         <form onSubmit={handleSubmit}>
                                                             <textarea
                                                                 placeholder="Add a comment"
-                                                                className="w-full p-3 text-black border border-gray-300 rounded focus:outline-none focus:border-gray-600"
+                                                                className="w-full p-3 bg-comment-compat border border-gray-300 rounded focus:outline-none focus:border-gray-600"
                                                                 onChange={e => setNewComment(e.target.value)}
                                                                 value={newComment}
                                                             >

--- a/client/src/styles/global-styles.ts
+++ b/client/src/styles/global-styles.ts
@@ -16,6 +16,12 @@ export const GlobalStyles = createGlobalStyle`
         color: #C7C8CC;
       }
     }
+    .bg-compat {
+      background-color: #374151;
+    }
+    .bg-comment-compat {
+      background-color: #374151;
+    }
     .hover-bg-compat:hover {
       background-color: #1F2937;
     }
@@ -48,7 +54,12 @@ export const GlobalStyles = createGlobalStyle`
   .light {
     background-color: #f7fafc;
     color: #1a202c;
-
+    .bg-compat {
+      background-color: #F3F4F6;
+    }
+    .bg-comment-compat {
+      background-color: #f7fafc;
+    }
     .hover-bg-compat:hover {
       background-color: #edf2f7;
     }


### PR DESCRIPTION
## Problem
- AI 답변 생성되는 부분의 텍스트가 다크모드에서 안보이는 문제

## How to Solve
- 원인 : 텍스트 색상을 지정하지 않아서 다크 모드일 떄 global 속성에 따라 #f7fafc (매우 밝은 회색)으로 바뀌는데, bg-gray-100으로 지정되어 있어서 글자가 보이지 않음
- 해결 : bg-compat, bg-comment-compat 설정 추가 

## Result
- light mode
   <img src=https://github.com/user-attachments/assets/0ea3c81d-a468-4d17-82ec-111198d2bc03 width=500>
- dark mode
   <img src=https://github.com/user-attachments/assets/17a8ca69-4d98-47b7-82e7-06615622cd53 width=500>